### PR TITLE
Add Plotly comparison embeds to 2026 weekly viz posts

### DIFF
--- a/_posts/projects/data_viz/2026-02-02-WeeklyViz20260202.md
+++ b/_posts/projects/data_viz/2026-02-02-WeeklyViz20260202.md
@@ -45,6 +45,30 @@ I travel overseas multiple times every year. In the past two years, I went to Ja
 
 [Dashboard link](https://public.tableau.com/views/20260202InternationalTravelDestinations/InternationalTravelDestinations?:language=en-US&publish=yes&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below is the Plotly version for comparison.
+
+<div>
+  <iframe
+    id="weekly-viz-global-tourism-top20-compare"
+    src="/assets/viz/weekly-global-tourism-top20/index.html"
+    loading="lazy"
+    style="width:100%;height:960px;border:0;display:block;"
+    title="Global Tourism Is Still Concentrated at the Top">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-global-tourism-top20-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(560, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link](/assets/viz/weekly-global-tourism-top20/index.html)
+
 #### Insights
 * Among the top 10 destinations, 5 are from the Asia Pacific region, including two from Japan (Tokyo and Osaka);
 * Surprisingly, the most popular overnight travel destination in Europe in 2025 is Antalya, Turkey, instead of London and Paris.   

--- a/_posts/projects/data_viz/2026-02-09-WeeklyViz20260209.md
+++ b/_posts/projects/data_viz/2026-02-09-WeeklyViz20260209.md
@@ -46,6 +46,30 @@ I visualized this dataset in a circle, where the four layers represent the years
 
 [Dashboard link](https://public.tableau.com/views/20260209TheWorldsTop50PopulatedCities/TheWorldsTop50PopulatedCities?:language=en-US&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below is the Plotly version for comparison.
+
+<div>
+  <iframe
+    id="weekly-viz-world-cities-bump-compare"
+    src="/assets/viz/weekly-world-cities-bump/index.html"
+    loading="lazy"
+    style="width:100%;height:940px;border:0;display:block;"
+    title="The Urban Order Is Tilting Toward Asia and Africa">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-world-cities-bump-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(560, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link](/assets/viz/weekly-world-cities-bump/index.html)
+
 #### Insights
 * Half (26/50) of the top populated cities in the world are located in Asia;
 * The population rank has shifted over time to South and Southeast Asia countries -- for example, Osaka (Japan) was ranked 2nd and NYC was ranked in 3rd in 1975, but their populations will be ranked beyond 20th places in 2050. Meanwhile, New Delhi was ranked 17th and Karachi was ranked 22nd in 1975, but will be 4th and 5th places in 2050.   

--- a/_posts/projects/data_viz/2026-02-16-WeeklyViz20260216.md
+++ b/_posts/projects/data_viz/2026-02-16-WeeklyViz20260216.md
@@ -47,6 +47,30 @@ My visualization is a hexmap with a parameter to switch among the top 1st, 2nd, 
 
 [Dashboard link](https://public.tableau.com/views/20260216MostPostedJobsintheUS/MostPostedJobsintheUS?:language=en-US&publish=yes&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below is the Plotly version for comparison.
+
+<div>
+  <iframe
+    id="weekly-viz-state-jobs-sankey-compare"
+    src="/assets/viz/weekly-state-jobs-sankey/index.html"
+    loading="lazy"
+    style="width:100%;height:940px;border:0;display:block;"
+    title="One Job Owns the No. 1 Slot Across Almost Every State">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-state-jobs-sankey-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(480, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link](/assets/viz/weekly-state-jobs-sankey/index.html)
+
 #### Insights
 * Registered nurse is the most posted job in 49 of the 50 states in 2025;
 * The 2nd most posted jobs in each state have more variety -- the most common one is retail sales assotiate, followed by tractor-trailer truck driver.  

--- a/_posts/projects/data_viz/2026-02-23-WeeklyViz20260223.md
+++ b/_posts/projects/data_viz/2026-02-23-WeeklyViz20260223.md
@@ -47,6 +47,30 @@ My visualization consists of three columns -- The first two columns are bar char
 
 [Dashboard link](https://public.tableau.com/views/20260223PerCapitaWealth/PerCapitaWealth?:language=en-US&publish=yes&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below is the Plotly version for comparison.
+
+<div>
+  <iframe
+    id="weekly-viz-top1-wealth-compare"
+    src="/assets/viz/weekly-top1-wealth-dumbbell/index.html"
+    loading="lazy"
+    style="width:100%;height:860px;border:0;display:block;"
+    title="The Top 1% Live in a Different Wealth Universe">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-top1-wealth-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(480, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link](/assets/viz/weekly-top1-wealth-dumbbell/index.html)
+
 #### Insights
 * While the top 1% per capita wealth is the highest in the US, the bottom 50% per capita wealth in the US is much lower than in most of the other major economies;
 * Across all the major economies in this dataset, the U.K. has the lowest top 1% share of wealth at 21%.  

--- a/_posts/projects/data_viz/2026-03-02-WeeklyViz20260302.md
+++ b/_posts/projects/data_viz/2026-03-02-WeeklyViz20260302.md
@@ -47,6 +47,55 @@ I tried Radial Sankey Chart for the first time in this visualization -- it is cr
 
 [Dashboard link](https://public.tableau.com/views/20260302TopAirTravelPairs/TopAirTravelPairs?:language=en-US&publish=yes&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below are two Plotly versions for comparison.
+
+**Connected dot version**
+
+<div>
+  <iframe
+    id="weekly-viz-air-routes-connected-dots-compare"
+    src="/assets/viz/weekly-air-routes-connected-dots/index.html"
+    loading="lazy"
+    style="width:100%;height:920px;border:0;display:block;"
+    title="Top Air Routes Converge on a Few Destinations">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-air-routes-connected-dots-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(480, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link (connected dot version)](/assets/viz/weekly-air-routes-connected-dots/index.html)
+
+**Flow map version**
+
+<div>
+  <iframe
+    id="weekly-viz-air-routes-map-compare"
+    src="/assets/viz/weekly-air-routes-map/index.html"
+    loading="lazy"
+    style="width:100%;height:840px;border:0;display:block;"
+    title="The Busiest Air Corridors Pull Toward a Few Countries">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-air-routes-map-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(480, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link (flow map version)](/assets/viz/weekly-air-routes-map/index.html)
+
 #### Insights
 * The most popular flight routes are mostly within the same continent, as shorter flights can run multiple times per day;  
 * Spain is Europe's largest destination and routes from/to Spain appears four times in the top 20.    

--- a/_posts/projects/data_viz/2026-03-09-WeeklyViz20260309.md
+++ b/_posts/projects/data_viz/2026-03-09-WeeklyViz20260309.md
@@ -47,6 +47,30 @@ This visualization is a bar chart -- I also used a complementary grey bar to hig
 
 [Dashboard link](https://public.tableau.com/views/20260309LargestRestaurantChainsbyMarketCap/LargestRestaurantChainsbyMarketCap?:language=en-US&publish=yes&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below is the Plotly version for comparison.
+
+<div>
+  <iframe
+    id="weekly-viz-restaurant-marketcap-compare"
+    src="/assets/viz/weekly-restaurant-marketcap-ranking/index.html"
+    loading="lazy"
+    style="width:100%;height:820px;border:0;display:block;"
+    title="McDonald Towers Over Public Restaurant Chains">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-restaurant-marketcap-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(480, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link](/assets/viz/weekly-restaurant-marketcap-ranking/index.html)
+
 #### Insights
 * Half of the top 20 restaurant chains are US brands;
 * The chain in the 2nd place is Yum!Brand, which operates KFC, Pizza Hut, Taco Bell, Habit Burger & Grill, etc.  

--- a/_posts/projects/data_viz/2026-03-16-WeeklyViz20260316.md
+++ b/_posts/projects/data_viz/2026-03-16-WeeklyViz20260316.md
@@ -46,6 +46,30 @@ This week's visualization is a scatter chart -- x-axis is the population and y-a
 
 [Dashboard link](https://public.tableau.com/views/20260316Populationvs_HouseholdsAroundtheWrold/Populationvs_HouseholdsAroundtheWrold?:language=en-US&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below is the Plotly version for comparison.
+
+<div>
+  <iframe
+    id="weekly-viz-households-compare"
+    src="/assets/viz/weekly-households-scatter/index.html"
+    loading="lazy"
+    style="width:100%;height:760px;border:0;display:block;"
+    title="Population Doesn't Equal Households">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-households-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(480, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link](/assets/viz/weekly-households-scatter/index.html)
+
 #### Insights
 * Population and # of households are mostly linearly correlated with an average household size of ~3.9;
 * The country with the highest avg household size is Senegal (8.7).  

--- a/_posts/projects/data_viz/2026-03-23-WeeklyViz20260323.md
+++ b/_posts/projects/data_viz/2026-03-23-WeeklyViz20260323.md
@@ -46,6 +46,30 @@ This week's visualization is mainly a Gantt chart. I combined it with shapes on 
 
 [Dashboard link](https://public.tableau.com/views/20260323USYoYRentalCosts/USYoYRentalCosts?:language=en-US&publish=yes&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below is the Plotly version for comparison.
+
+<div>
+  <iframe
+    id="weekly-viz-zori-compare"
+    src="/assets/viz/weekly-zori-quadrant/index.html"
+    loading="lazy"
+    style="width:100%;height:760px;border:0;display:block;"
+    title="Which Rental Markets Cooled After the Pandemic Boom?">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-zori-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(480, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link](/assets/viz/weekly-zori-quadrant/index.html)
+
 #### Insights
 * Among the top 20 largest regions in the US, San Francisco saw the highest rent increases in the past year (6.3%);
 * New York saw 4.2% y/y rent increase, and has the highest rent in 2026 among the top 20 regions.  

--- a/_posts/projects/data_viz/2026-03-30-WeeklyViz20260330.md
+++ b/_posts/projects/data_viz/2026-03-30-WeeklyViz20260330.md
@@ -47,6 +47,30 @@ I chose the Gantt chart again, as it is a great way to show the difference betwe
 
 [Dashboard link](https://public.tableau.com/views/20260330CostofLivingChinavs_India/CostofLivingChinavs_India?:language=en-US&publish=yes&:sid=&:redirect=auth&:display_count=n&:origin=viz_share_link)
 
+#### Plotly Comparison
+Below is the Plotly version for comparison.
+
+<div>
+  <iframe
+    id="weekly-viz-india-china-dumbbell-compare"
+    src="/assets/viz/weekly-india-china-dumbbell/index.html"
+    loading="lazy"
+    style="width:100%;height:980px;border:0;display:block;"
+    title="China Usually Costs More, But Not Always">
+  </iframe>
+</div>
+
+<script>
+  window.addEventListener('message', function (event) {
+    var frame = document.getElementById('weekly-viz-india-china-dumbbell-compare');
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (!event.data || event.data.type !== 'weekly-viz-height') return;
+    frame.style.height = Math.max(480, event.data.height) + 'px';
+  });
+</script>
+
+[Plotly dashboard link](/assets/viz/weekly-india-china-dumbbell/index.html)
+
 #### Insights
 * As the monthly net salary is higher in China, most things on the list are more expensive in China, with the exception of Cappuccino and beer;
 * The item that has the highest cost difference is the monthly fitness club membership -- it costs almost 3x in China ($41.25 vs. $14.75).  

--- a/assets/viz/weekly-air-routes-connected-dots/index.html
+++ b/assets/viz/weekly-air-routes-connected-dots/index.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Top Air Routes Converge on a Few Destinations</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      --bg: #fcfbf7;
+      --text: #171717;
+      --muted: #666666;
+      --grid: #e6e0d8;
+      --origin: #cfc6bb;
+      --other: #bfb5aa;
+      --usa: #c65534;
+      --uk: #2b6f95;
+      --spain: #d28c2c;
+      --korea: #4f8b5f;
+      --uae: #7a57a8;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .wrap {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 22px 18px 10px;
+    }
+
+    .chart-header {
+      margin-bottom: 10px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 34px;
+      line-height: 1.08;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .chart-subtitle,
+    .chart-note,
+    .source {
+      max-width: 980px;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.45;
+      color: #2f2f2f;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: var(--muted);
+    }
+
+    #chart {
+      width: 100%;
+      height: 860px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    .source a {
+      color: #2569a8;
+    }
+
+    @media (max-width: 760px) {
+      .wrap {
+        padding: 16px 12px 8px;
+      }
+
+      .chart-title {
+        font-size: 28px;
+      }
+
+      .chart-subtitle {
+        font-size: 16px;
+      }
+
+      .chart-note,
+      .source {
+        font-size: 14px;
+      }
+
+      #chart {
+        height: 980px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="chart-header">
+      <h1 class="chart-title">
+        Top Air Routes <span style="color: var(--usa);">Converge</span> on a Few Destinations
+      </h1>
+      <p class="chart-subtitle">
+        In this top-20 snapshot of international seat capacity, the busiest corridors do not spread evenly across the globe. The USA, United Kingdom, Spain, Korea Republic of, and the UAE appear repeatedly on the destination side.
+      </p>
+      <p class="chart-note">
+        Each line connects one origin country on the left to one destination country on the right. Line width encodes seat capacity, and color highlights recurring destination countries rather than geography on a map.
+      </p>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Source:
+      <a href="https://www.oag.com/airline-frequency-and-capacity-statistics" target="_blank" rel="noreferrer">OAG airline frequency and capacity statistics</a>.
+      Caveat: this file contains only the top 20 route-country pairs in the snapshot, not a full global route network.
+    </div>
+  </div>
+
+  <script>
+    function reportHeight() {
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const rows = [
+      { rank: 1, from: "Mexico", to: "USA", seats: 4112126 },
+      { rank: 2, from: "Spain", to: "United Kingdom", seats: 3099508 },
+      { rank: 3, from: "Japan", to: "Korea Republic of", seats: 2860218 },
+      { rank: 4, from: "Canada", to: "USA", seats: 2576117 },
+      { rank: 5, from: "India", to: "United Arab Emirates", seats: 2084744 },
+      { rank: 6, from: "Germany", to: "Spain", seats: 1836316 },
+      { rank: 7, from: "China", to: "Thailand", seats: 1717336 },
+      { rank: 8, from: "Italy", to: "Spain", seats: 1689348 },
+      { rank: 9, from: "Chinese Taipei", to: "Japan", seats: 1651813 },
+      { rank: 10, from: "United Kingdom", to: "USA", seats: 1566553 },
+      { rank: 11, from: "China", to: "Korea Republic of", seats: 1560884 },
+      { rank: 12, from: "Egypt", to: "Saudi Arabia", seats: 1503595 },
+      { rank: 13, from: "China", to: "Hong Kong (SAR) China", seats: 1435143 },
+      { rank: 14, from: "Italy", to: "United Kingdom", seats: 1236691 },
+      { rank: 15, from: "Ireland Republic of", to: "United Kingdom", seats: 1231582 },
+      { rank: 16, from: "Saudi Arabia", to: "United Arab Emirates", seats: 1172680 },
+      { rank: 17, from: "France", to: "Spain", seats: 1155358 },
+      { rank: 18, from: "China", to: "Malaysia", seats: 1130485 },
+      { rank: 19, from: "Germany", to: "United Kingdom", seats: 1111280 },
+      { rank: 20, from: "Germany", to: "Turkiye", seats: 1109190 }
+    ];
+
+    const destinationColors = {
+      "USA": "#c65534",
+      "United Kingdom": "#2b6f95",
+      "Spain": "#d28c2c",
+      "Korea Republic of": "#4f8b5f",
+      "United Arab Emirates": "#7a57a8"
+    };
+
+    const lineTraces = [];
+    const originX = 0.14;
+    const destX = 0.86;
+    const yValues = rows.map((_, i) => rows.length - i);
+
+    function seatLabel(seats) {
+      return `${(seats / 1000000).toFixed(2)}M`;
+    }
+
+    rows.forEach((row, i) => {
+      const y = yValues[i];
+      const width = 2 + ((row.seats - 1100000) / (4112126 - 1100000)) * 10;
+      const color = destinationColors[row.to] || "#bfb5aa";
+      lineTraces.push({
+        type: "scatter",
+        mode: "lines",
+        x: [originX, destX],
+        y: [y, y],
+        line: { color, width },
+        opacity: row.rank === 1 ? 0.95 : 0.8,
+        hoverinfo: "skip",
+        showlegend: false
+      });
+    });
+
+    const originTrace = {
+      type: "scatter",
+      mode: "markers",
+      x: rows.map(() => originX),
+      y: yValues,
+      marker: {
+        color: "#cfc6bb",
+        size: 10,
+        line: { color: "#fcfbf7", width: 1.4 }
+      },
+      customdata: rows.map((r) => [r.rank, r.from, r.to, r.seats]),
+      hovertemplate:
+        "<b>#%{customdata[0]}</b><br>" +
+        "%{customdata[1]} → %{customdata[2]}<br>" +
+        "Seats: %{customdata[3]:,}<extra></extra>",
+      showlegend: false
+    };
+
+    const destTrace = {
+      type: "scatter",
+      mode: "markers",
+      x: rows.map(() => destX),
+      y: yValues,
+      marker: {
+        color: rows.map((r) => destinationColors[r.to] || "#bfb5aa"),
+        size: 12,
+        line: { color: "#fcfbf7", width: 1.6 }
+      },
+      customdata: rows.map((r) => [r.rank, r.from, r.to, r.seats]),
+      hovertemplate:
+        "<b>#%{customdata[0]}</b><br>" +
+        "%{customdata[1]} → %{customdata[2]}<br>" +
+        "Seats: %{customdata[3]:,}<extra></extra>",
+      showlegend: false
+    };
+
+    const annotations = [
+      {
+        x: destX,
+        y: yValues[0],
+        xref: "x",
+        yref: "y",
+        text: "Mexico → USA is the biggest corridor<br>in this top-20 snapshot",
+        showarrow: true,
+        arrowcolor: "#c65534",
+        ax: -132,
+        ay: -20,
+        bgcolor: "rgba(252,251,247,0.96)",
+        bordercolor: "rgba(198,85,52,0.2)",
+        borderwidth: 1,
+        font: { size: 12, color: "#7b3b28" },
+        align: "left"
+      },
+      {
+        x: destX,
+        y: yValues[9],
+        xref: "x",
+        yref: "y",
+        text: "The same few destinations<br>keep appearing on the right",
+        showarrow: true,
+        arrowcolor: "#6e655c",
+        ax: 115,
+        ay: 18,
+        bgcolor: "rgba(252,251,247,0.96)",
+        bordercolor: "rgba(110,101,92,0.22)",
+        borderwidth: 1,
+        font: { size: 12, color: "#5b554e" },
+        align: "left"
+      }
+    ];
+
+    rows.forEach((row, i) => {
+      const y = yValues[i];
+      annotations.push({
+        x: originX - 0.02,
+        y,
+        xref: "x",
+        yref: "y",
+        text: row.from,
+        showarrow: false,
+        xanchor: "right",
+        font: { size: 12, color: "#2e2e2e" },
+        align: "right"
+      });
+      annotations.push({
+        x: 0.5,
+        y,
+        xref: "x",
+        yref: "y",
+        text: seatLabel(row.seats),
+        showarrow: false,
+        font: { size: 11, color: "#776f67" },
+        align: "center"
+      });
+      annotations.push({
+        x: destX + 0.02,
+        y,
+        xref: "x",
+        yref: "y",
+        text: row.to,
+        showarrow: false,
+        xanchor: "left",
+        font: {
+          size: 12,
+          color: destinationColors[row.to] || "#5c5852"
+        },
+        align: "left"
+      });
+    });
+
+    const layout = {
+      paper_bgcolor: "#fcfbf7",
+      plot_bgcolor: "#fcfbf7",
+      font: {
+        family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+        color: "#222222",
+        size: 14
+      },
+      margin: { l: 120, r: 160, t: 48, b: 24 },
+      xaxis: {
+        range: [0, 1],
+        showgrid: false,
+        zeroline: false,
+        showticklabels: false,
+        fixedrange: true
+      },
+      yaxis: {
+        range: [0.4, rows.length + 1.4],
+        showgrid: false,
+        zeroline: false,
+        showticklabels: false,
+        fixedrange: true
+      },
+      showlegend: false,
+      annotations
+    };
+
+    const config = {
+      responsive: true,
+      displayModeBar: false
+    };
+
+    Plotly.newPlot("chart", [...lineTraces, originTrace, destTrace], layout, config).then(() => {
+      reportHeight();
+      window.addEventListener("resize", reportHeight);
+      setTimeout(reportHeight, 120);
+    });
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-air-routes-map/index.html
+++ b/assets/viz/weekly-air-routes-map/index.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Busiest Air Corridors Pull Toward a Few Countries</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      --bg: #fcfbf7;
+      --text: #171717;
+      --muted: #666666;
+      --line: #c8beb3;
+      --origin: #d8d0c6;
+      --usa: #c65534;
+      --uk: #2b6f95;
+      --spain: #d28c2c;
+      --korea: #4f8b5f;
+      --uae: #7a57a8;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .wrap {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 22px 18px 10px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 34px;
+      line-height: 1.08;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .chart-subtitle,
+    .chart-note,
+    .source {
+      max-width: 980px;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.45;
+      color: #2f2f2f;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: var(--muted);
+    }
+
+    .legend-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      margin: 0 0 10px;
+      font-size: 14px;
+      color: #4a4a4a;
+    }
+
+    .legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+    }
+
+    .legend-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+      display: inline-block;
+    }
+
+    #chart {
+      width: 100%;
+      height: 760px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    .source a {
+      color: #2569a8;
+    }
+
+    @media (max-width: 760px) {
+      .wrap {
+        padding: 16px 12px 8px;
+      }
+
+      .chart-title {
+        font-size: 28px;
+      }
+
+      .chart-subtitle {
+        font-size: 16px;
+      }
+
+      .chart-note,
+      .source,
+      .legend-row {
+        font-size: 14px;
+      }
+
+      #chart {
+        height: 820px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1 class="chart-title">
+      The Busiest Air Corridors Pull Toward a Few <span style="color: var(--usa);">Countries</span>
+    </h1>
+    <p class="chart-subtitle">
+      In this top-20 snapshot of international seat capacity, the heaviest country-to-country corridors repeatedly land in the USA, United Kingdom, Spain, Korea Republic of, and the UAE.
+    </p>
+    <p class="chart-note">
+      This map draws country-to-country connections between approximate country centroids, not airport-to-airport routes. It is meant to show directional concentration, not literal flight paths.
+    </p>
+    <div class="legend-row" aria-label="Highlighted destination countries">
+      <span class="legend-item"><span class="legend-dot" style="background:#c65534"></span>USA</span>
+      <span class="legend-item"><span class="legend-dot" style="background:#2b6f95"></span>United Kingdom</span>
+      <span class="legend-item"><span class="legend-dot" style="background:#d28c2c"></span>Spain</span>
+      <span class="legend-item"><span class="legend-dot" style="background:#4f8b5f"></span>Korea Republic of</span>
+      <span class="legend-item"><span class="legend-dot" style="background:#7a57a8"></span>United Arab Emirates</span>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Source:
+      <a href="https://www.oag.com/airline-frequency-and-capacity-statistics" target="_blank" rel="noreferrer">OAG airline frequency and capacity statistics</a>.
+      Caveat: this file contains only the top 20 country-pair routes in the snapshot, not a complete global route network.
+    </div>
+  </div>
+
+  <script>
+    function reportHeight() {
+      const height = Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const coords = {
+      "Mexico": { lat: 23.63, lon: -102.55 },
+      "USA": { lat: 39.83, lon: -98.58 },
+      "Spain": { lat: 40.46, lon: -3.75 },
+      "United Kingdom": { lat: 55.38, lon: -3.44 },
+      "Japan": { lat: 36.2, lon: 138.25 },
+      "Korea Republic of": { lat: 35.91, lon: 127.77 },
+      "Canada": { lat: 56.13, lon: -106.35 },
+      "India": { lat: 20.59, lon: 78.96 },
+      "United Arab Emirates": { lat: 23.42, lon: 53.85 },
+      "Germany": { lat: 51.17, lon: 10.45 },
+      "China": { lat: 35.86, lon: 104.19 },
+      "Thailand": { lat: 15.87, lon: 100.99 },
+      "Italy": { lat: 41.87, lon: 12.57 },
+      "Chinese Taipei": { lat: 23.7, lon: 121.0 },
+      "Egypt": { lat: 26.82, lon: 30.8 },
+      "Saudi Arabia": { lat: 23.89, lon: 45.08 },
+      "Hong Kong (SAR) China": { lat: 22.32, lon: 114.17 },
+      "Ireland Republic of": { lat: 53.14, lon: -7.69 },
+      "France": { lat: 46.23, lon: 2.21 },
+      "Malaysia": { lat: 4.21, lon: 101.98 },
+      "Turkiye": { lat: 38.96, lon: 35.24 }
+    };
+
+    const rows = [
+      { rank: 1, from: "Mexico", to: "USA", seats: 4112126 },
+      { rank: 2, from: "Spain", to: "United Kingdom", seats: 3099508 },
+      { rank: 3, from: "Japan", to: "Korea Republic of", seats: 2860218 },
+      { rank: 4, from: "Canada", to: "USA", seats: 2576117 },
+      { rank: 5, from: "India", to: "United Arab Emirates", seats: 2084744 },
+      { rank: 6, from: "Germany", to: "Spain", seats: 1836316 },
+      { rank: 7, from: "China", to: "Thailand", seats: 1717336 },
+      { rank: 8, from: "Italy", to: "Spain", seats: 1689348 },
+      { rank: 9, from: "Chinese Taipei", to: "Japan", seats: 1651813 },
+      { rank: 10, from: "United Kingdom", to: "USA", seats: 1566553 },
+      { rank: 11, from: "China", to: "Korea Republic of", seats: 1560884 },
+      { rank: 12, from: "Egypt", to: "Saudi Arabia", seats: 1503595 },
+      { rank: 13, from: "China", to: "Hong Kong (SAR) China", seats: 1435143 },
+      { rank: 14, from: "Italy", to: "United Kingdom", seats: 1236691 },
+      { rank: 15, from: "Ireland Republic of", to: "United Kingdom", seats: 1231582 },
+      { rank: 16, from: "Saudi Arabia", to: "United Arab Emirates", seats: 1172680 },
+      { rank: 17, from: "France", to: "Spain", seats: 1155358 },
+      { rank: 18, from: "China", to: "Malaysia", seats: 1130485 },
+      { rank: 19, from: "Germany", to: "United Kingdom", seats: 1111280 },
+      { rank: 20, from: "Germany", to: "Turkiye", seats: 1109190 }
+    ];
+
+    const destinationColors = {
+      "USA": "#c65534",
+      "United Kingdom": "#2b6f95",
+      "Spain": "#d28c2c",
+      "Korea Republic of": "#4f8b5f",
+      "United Arab Emirates": "#7a57a8"
+    };
+
+    const traces = rows.map((row) => {
+      const from = coords[row.from];
+      const to = coords[row.to];
+      const width = 1.5 + ((row.seats - 1109190) / (4112126 - 1109190)) * 6.5;
+      const color = destinationColors[row.to] || "#bfb5aa";
+      return {
+        type: "scattergeo",
+        mode: "lines",
+        lon: [from.lon, to.lon],
+        lat: [from.lat, to.lat],
+        line: { width, color },
+        opacity: row.rank === 1 ? 0.92 : 0.72,
+        hovertemplate:
+          `<b>#${row.rank}</b><br>${row.from} → ${row.to}<br>Seats: ${row.seats.toLocaleString()}<extra></extra>`,
+        showlegend: false
+      };
+    });
+
+    const originCountries = Array.from(new Set(rows.map((r) => r.from)));
+    const destinationCountries = Array.from(new Set(rows.map((r) => r.to)));
+
+    const originTrace = {
+      type: "scattergeo",
+      mode: "markers",
+      lon: originCountries.map((c) => coords[c].lon),
+      lat: originCountries.map((c) => coords[c].lat),
+      text: originCountries,
+      marker: {
+        size: 7,
+        color: "#d8d0c6",
+        line: { color: "#fcfbf7", width: 1 }
+      },
+      hovertemplate: "<b>%{text}</b><br>Origin country<extra></extra>",
+      showlegend: false
+    };
+
+    const destinationTrace = {
+      type: "scattergeo",
+      mode: "markers+text",
+      lon: destinationCountries.map((c) => coords[c].lon),
+      lat: destinationCountries.map((c) => coords[c].lat),
+      text: destinationCountries.map((c) => {
+        const shortNames = {
+          "United Kingdom": "UK",
+          "Korea Republic of": "Korea Rep.",
+          "United Arab Emirates": "UAE",
+          "Hong Kong (SAR) China": "Hong Kong"
+        };
+        return shortNames[c] || c;
+      }),
+      textposition: "top center",
+      textfont: {
+        size: 11,
+        color: destinationCountries.map((c) => destinationColors[c] || "#59534d")
+      },
+      marker: {
+        size: destinationCountries.map((c) => (destinationColors[c] ? 10 : 8)),
+        color: destinationCountries.map((c) => destinationColors[c] || "#bfb5aa"),
+        line: { color: "#fcfbf7", width: 1.3 }
+      },
+      hovertemplate: "<b>%{text}</b><br>Destination country<extra></extra>",
+      showlegend: false
+    };
+
+    const layout = {
+      paper_bgcolor: "#fcfbf7",
+      margin: { l: 10, r: 10, t: 10, b: 10 },
+      geo: {
+        projection: { type: "natural earth" },
+        bgcolor: "#fcfbf7",
+        showland: true,
+        landcolor: "#f3eee8",
+        showocean: true,
+        oceancolor: "#ffffff",
+        showcountries: true,
+        countrycolor: "#ddd4c9",
+        coastlinecolor: "#ddd4c9",
+        lataxis: { range: [-45, 75] }
+      },
+      annotations: [
+        {
+          xref: "paper",
+          yref: "paper",
+          x: 0.27,
+          y: 0.58,
+          text: "Mexico → USA is the biggest<br>country-pair corridor here",
+          showarrow: true,
+          arrowcolor: "#c65534",
+          ax: -38,
+          ay: -42,
+          bgcolor: "rgba(252,251,247,0.96)",
+          bordercolor: "rgba(198,85,52,0.2)",
+          borderwidth: 1,
+          font: { size: 12, color: "#7b3b28" },
+          align: "left"
+        },
+        {
+          xref: "paper",
+          yref: "paper",
+          x: 0.72,
+          y: 0.62,
+          text: "A few destination countries<br>attract repeated top flows",
+          showarrow: true,
+          arrowcolor: "#6b645d",
+          ax: 84,
+          ay: -22,
+          bgcolor: "rgba(252,251,247,0.96)",
+          bordercolor: "rgba(107,100,93,0.22)",
+          borderwidth: 1,
+          font: { size: 12, color: "#5b554e" },
+          align: "left"
+        }
+      ]
+    };
+
+    Plotly.newPlot("chart", [...traces, originTrace, destinationTrace], layout, {
+      responsive: true,
+      displayModeBar: false
+    }).then(() => {
+      reportHeight();
+      window.addEventListener("resize", reportHeight);
+      setTimeout(reportHeight, 120);
+    });
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-global-tourism-top20/index.html
+++ b/assets/viz/weekly-global-tourism-top20/index.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Global Tourism Is Still Concentrated at the Top</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      --bg: #fcfbf7;
+      --text: #171717;
+      --muted: #666666;
+      --grid: #e6e0d8;
+      --link: #2569a8;
+      --apac: #c65a3a;
+      --europe: #6d8da4;
+      --mea: #8b61b4;
+      --americas: #9a6a3a;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .wrap {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 22px 18px 10px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 35px;
+      line-height: 1.08;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      max-width: 980px;
+    }
+
+    .chart-subtitle,
+    .chart-note,
+    .source {
+      max-width: 980px;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.45;
+      color: #2f2f2f;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: var(--muted);
+    }
+
+    .legend-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      align-items: center;
+      margin-bottom: 8px;
+      font-size: 14px;
+      color: #4b4b4b;
+    }
+
+    .legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .legend-swatch {
+      width: 14px;
+      height: 14px;
+      border-radius: 3px;
+      display: inline-block;
+    }
+
+    #chart {
+      width: 100%;
+      height: 900px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    .source a {
+      color: var(--link);
+    }
+
+    @media (max-width: 760px) {
+      .wrap {
+        padding: 16px 12px 8px;
+      }
+
+      .chart-title {
+        font-size: 29px;
+      }
+
+      .chart-subtitle {
+        font-size: 16px;
+      }
+
+      .chart-note,
+      .legend-row,
+      .source {
+        font-size: 14px;
+      }
+
+      #chart {
+        height: 980px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1 class="chart-title">
+      Global Tourism Is Still <span style="color: var(--apac);">Concentrated</span> at the Top
+    </h1>
+    <p class="chart-subtitle">
+      Tokyo leads the 2025 ranking, but the larger pattern is concentration: a small top tier of Asian, European, and Middle Eastern destinations absorbs an outsized share of international overnight arrivals.
+    </p>
+    <p class="chart-note">
+      This chart is built from the explicit top-20 ranking figures stated in the article’s “Highlights of the Global Top 100 Destinations” section. The article contains a few later spot-value inconsistencies for some destinations, so this view follows the ranked snapshot rather than the later growth callouts. The Turkey methodology note in the article also means Antalya and Istanbul should be read as 2025 overnight-stay destinations, not a directly unchanged historical series.
+    </p>
+    <div class="legend-row" aria-label="Region legend">
+      <span class="legend-item"><span class="legend-swatch" style="background:#c65a3a"></span>Asia Pacific</span>
+      <span class="legend-item"><span class="legend-swatch" style="background:#6d8da4"></span>Europe</span>
+      <span class="legend-item"><span class="legend-swatch" style="background:#8b61b4"></span>Middle East &amp; Africa</span>
+      <span class="legend-item"><span class="legend-swatch" style="background:#9a6a3a"></span>Americas</span>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Source:
+      <a href="https://thequietanalyst.substack.com/p/global-tourism-in-2025" target="_blank" rel="noreferrer">The Quiet Analyst, “Global Tourism in 2025”</a>.
+      Data used here: the article’s stated top-20 global destination ranking by 2025 international overnight arrivals.
+    </div>
+  </div>
+
+  <script>
+    const rows = [
+      { rank: 1, destination: "Tokyo", country: "Japan", region: "Asia Pacific", arrivals: 26.0, type: "Gateway" },
+      { rank: 2, destination: "Bangkok", country: "Thailand", region: "Asia Pacific", arrivals: 24.8, type: "Gateway" },
+      { rank: 3, destination: "Antalya", country: "Türkiye", region: "Europe", arrivals: 23.5, type: "Leisure resort" },
+      { rank: 4, destination: "London", country: "United Kingdom", region: "Europe", arrivals: 21.2, type: "Gateway" },
+      { rank: 5, destination: "Dubai", country: "United Arab Emirates", region: "Middle East & Africa", arrivals: 19.6, type: "Hub" },
+      { rank: 6, destination: "Makkah", country: "Saudi Arabia", region: "Middle East & Africa", arrivals: 18.0, type: "Religious destination" },
+      { rank: 7, destination: "Paris", country: "France", region: "Europe", arrivals: 15.2, type: "Gateway" },
+      { rank: 8, destination: "Kuala Lumpur", country: "Malaysia", region: "Asia Pacific", arrivals: 17.2, type: "Gateway" },
+      { rank: 9, destination: "Osaka", country: "Japan", region: "Asia Pacific", arrivals: 14.3, type: "Gateway" },
+      { rank: 10, destination: "Seoul", country: "Republic of Korea", region: "Asia Pacific", arrivals: 12.6, type: "Gateway" },
+      { rank: 11, destination: "Singapore", country: "Singapore", region: "Asia Pacific", arrivals: 12.6, type: "Gateway" },
+      { rank: 12, destination: "Istanbul", country: "Türkiye", region: "Europe", arrivals: 11.7, type: "Gateway" },
+      { rank: 13, destination: "New York", country: "United States", region: "Americas", arrivals: 11.4, type: "Gateway" },
+      { rank: 14, destination: "Mallorca", country: "Spain", region: "Europe", arrivals: 11.0, type: "Leisure destination" },
+      { rank: 15, destination: "Barcelona", country: "Spain", region: "Europe", arrivals: 10.3, type: "Gateway" },
+      { rank: 16, destination: "Pattaya", country: "Thailand", region: "Asia Pacific", arrivals: 10.2, type: "Leisure destination" },
+      { rank: 17, destination: "Phuket", country: "Thailand", region: "Asia Pacific", arrivals: 10.0, type: "Leisure destination" },
+      { rank: 18, destination: "Rome", country: "Italy", region: "Europe", arrivals: 9.8, type: "Gateway" },
+      { rank: 19, destination: "Kyoto", country: "Japan", region: "Asia Pacific", arrivals: 8.9, type: "Gateway" },
+      { rank: 20, destination: "Venice", country: "Italy", region: "Europe", arrivals: 8.4, type: "Gateway" }
+    ];
+
+    const regionColors = {
+      "Asia Pacific": "#c65a3a",
+      "Europe": "#6d8da4",
+      "Middle East & Africa": "#8b61b4",
+      "Americas": "#9a6a3a"
+    };
+
+    function reportHeight() {
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const sorted = rows.slice().sort((a, b) => b.arrivals - a.arrivals);
+    const labels = sorted.map((d) => `${d.rank}. ${d.destination}`);
+    const arrivals = sorted.map((d) => d.arrivals);
+    const colors = sorted.map((d) => regionColors[d.region]);
+    const texts = sorted.map((d) => `${d.arrivals.toFixed(1)}m`);
+
+    function buildLayout() {
+      const mobile = window.innerWidth <= 760;
+      return {
+        paper_bgcolor: "#fcfbf7",
+        plot_bgcolor: "#fcfbf7",
+        font: {
+          family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+          color: "#222222",
+          size: mobile ? 13 : 14
+        },
+        margin: {
+          l: mobile ? 150 : 225,
+          r: mobile ? 70 : 78,
+          t: 8,
+          b: 48
+        },
+        xaxis: {
+          title: { text: "International overnight arrivals in 2025 (millions)", standoff: 12 },
+          showgrid: true,
+          gridcolor: "#e6e0d8",
+          zeroline: false,
+          range: [0, 27.5],
+          fixedrange: true
+        },
+        yaxis: {
+          automargin: true,
+          tickfont: { size: mobile ? 12 : 13 },
+          showgrid: false,
+          fixedrange: true
+        },
+        bargap: 0.24,
+        showlegend: false,
+        annotations: mobile ? [] : [
+          {
+            x: 26.0,
+            y: "1. Tokyo",
+            text: "Tokyo overtakes<br>Bangkok in 2025",
+            showarrow: true,
+            arrowcolor: "#c65a3a",
+            ax: -92,
+            ay: -18,
+            bgcolor: "rgba(252,251,247,0.96)",
+            bordercolor: "rgba(198,90,58,0.2)",
+            borderwidth: 1,
+            font: { size: 12, color: "#7b3b28" },
+            align: "left"
+          },
+          {
+            x: 23.5,
+            y: "3. Antalya",
+            text: "Largest leisure-resort<br>destination here",
+            showarrow: true,
+            arrowcolor: "#6d8da4",
+            ax: 100,
+            ay: 18,
+            bgcolor: "rgba(252,251,247,0.96)",
+            bordercolor: "rgba(109,141,164,0.2)",
+            borderwidth: 1,
+            font: { size: 12, color: "#425f72" },
+            align: "left"
+          }
+        ]
+      };
+    }
+
+    const trace = {
+      type: "bar",
+      orientation: "h",
+      x: arrivals.slice().reverse(),
+      y: labels.slice().reverse(),
+      marker: {
+        color: colors.slice().reverse(),
+        line: {
+          color: "#f7f2ec",
+          width: 1
+        }
+      },
+      customdata: sorted.map((d) => [d.country, d.region, d.type]).reverse(),
+      text: texts.slice().reverse(),
+      textposition: "outside",
+      cliponaxis: false,
+      hovertemplate:
+        "<b>%{y}</b><br>" +
+        "Arrivals: %{x:.1f} million<br>" +
+        "Country: %{customdata[0]}<br>" +
+        "Region: %{customdata[1]}<br>" +
+        "Destination type: %{customdata[2]}<extra></extra>"
+    };
+
+    const config = {
+      responsive: true,
+      displayModeBar: false
+    };
+
+    function renderChart() {
+      Plotly.newPlot("chart", [trace], buildLayout(), config).then(reportHeight);
+    }
+
+    let resizeTimer;
+    window.addEventListener("resize", () => {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(renderChart, 120);
+    });
+
+    renderChart();
+    window.addEventListener("load", reportHeight);
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-households-scatter/index.html
+++ b/assets/viz/weekly-households-scatter/index.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Population Doesn't Equal Households</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    body {
+      margin: 0;
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+      background: #ffffff;
+      color: #111111;
+    }
+
+    .wrap {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 20px 18px 8px;
+    }
+
+    .chart-header {
+      margin-bottom: 8px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 32px;
+      line-height: 1.12;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: #111111;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.4;
+      color: #333333;
+      max-width: 980px;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.35;
+      color: #666666;
+      max-width: 980px;
+    }
+
+    #chart {
+      width: 100%;
+      height: 760px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 15px;
+      color: #6d6d6d;
+    }
+
+    .source a {
+      color: #2c8fce;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="chart-header">
+      <h1 class="chart-title">
+        Population Doesn't Equal <span style="color:#4E79A7">Households</span>
+      </h1>
+      <p class="chart-subtitle">
+        Countries with similar population size can have very different numbers of households because household size varies sharply.
+      </p>
+      <p class="chart-note">
+        China and India have similarly massive populations, but China has far more households because its average household size is much smaller. Colors encode average people per household. Household distributions come from each country's most recent available survey year, which varies by country.
+      </p>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Data Source:
+      <a href="https://en.wikipedia.org/wiki/List_of_countries_by_number_of_households" target="_blank" rel="noreferrer">Countries by number of households</a>
+      | 151 countries with complete household-size information; household inputs are drawn from different country-year snapshots
+    </div>
+  </div>
+
+  <script>
+    function reportHeight() {
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const rows = [
+      {"country":"India","population":1425775850.0,"avg_hh":4.57,"households":294292700.0,"p1":4.11,"p23":27.31,"p45":41.64,"p6":26.94,"year":2015},
+      {"country":"China","population":1409778724.0,"avg_hh":2.8,"households":482427212.0,"p1":17.84,"p23":44.5,"p45":28.06,"p6":9.6,"year":2023},
+      {"country":"United States","population":330662999.0,"avg_hh":2.49,"households":125736353.0,"p1":27.89,"p23":49.49,"p45":18.81,"p6":3.81,"year":2020},
+      {"country":"Indonesia","population":269603400.0,"avg_hh":3.86,"households":69855344.0,"p1":7.1,"p23":36.62,"p45":41.5,"p6":14.78,"year":2017},
+      {"country":"Pakistan","population":220892331.0,"avg_hh":6.8,"households":32462785.0,"p1":1.08,"p23":12.88,"p45":25.16,"p6":60.88,"year":2013},
+      {"country":"Brazil","population":212347290.0,"avg_hh":3.31,"households":64124398.0,"p1":12.0,"p23":47.27,"p45":31.91,"p6":8.82,"year":2010},
+      {"country":"Nigeria","population":206139587.0,"avg_hh":4.9,"households":42057041.0,"p1":11.51,"p23":25.53,"p45":27.86,"p6":35.1,"year":2015},
+      {"country":"Bangladesh","population":169660274.0,"avg_hh":4.47,"households":37957746.0,"p1":1.74,"p23":29.71,"p45":45.59,"p6":22.96,"year":2014},
+      {"country":"Russia","population":146748590.0,"avg_hh":2.58,"households":56771478.0,"p1":25.97,"p23":50.83,"p45":19.55,"p6":3.65,"year":2010},
+      {"country":"Mexico","population":127792286.0,"avg_hh":3.74,"households":34167462.0,"p1":10.08,"p23":37.68,"p45":37.75,"p6":14.49,"year":2015},
+      {"country":"Japan","population":125800000.0,"avg_hh":2.26,"households":54310000.0,"p1":37.97,"p23":44.67,"p45":15.72,"p6":1.64,"year":2020},
+      {"country":"Philippines","population":109441605.0,"avg_hh":4.23,"households":25893157.0,"p1":9.18,"p23":30.05,"p45":36.82,"p6":23.95,"year":2017},
+      {"country":"DR Congo","population":101935800.0,"avg_hh":5.3,"households":19225670.0,"p1":7.25,"p23":21.19,"p45":27.81,"p6":43.74,"year":2013},
+      {"country":"Egypt","population":101189802.0,"avg_hh":4.13,"households":24496076.0,"p1":6.48,"p23":30.4,"p45":43.12,"p6":20.0,"year":2014},
+      {"country":"Ethiopia","population":100829000.0,"avg_hh":4.61,"households":21850103.0,"p1":7.52,"p23":27.01,"p45":32.0,"p6":33.47,"year":2016},
+      {"country":"Vietnam","population":96483981.0,"avg_hh":3.78,"households":25503951.0,"p1":7.28,"p23":36.25,"p45":43.44,"p6":13.02,"year":2009},
+      {"country":"Turkey","population":84140990.0,"avg_hh":3.14,"households":26309332.0,"p1":19.74,"p23":42.49,"p45":28.6,"p6":9.17,"year":2023},
+      {"country":"Iran","population":83955821.0,"avg_hh":3.49,"households":24056109.0,"p1":8.48,"p23":49.13,"p45":37.86,"p6":4.53,"year":2016},
+      {"country":"Germany","population":83122889.0,"avg_hh":2.05,"households":40624971.0,"p1":39.53,"p23":47.0,"p45":12.71,"p6":0.76,"year":2011},
+      {"country":"France","population":67146000.0,"avg_hh":2.22,"households":30243926.0,"p1":35.46,"p23":46.84,"p45":16.08,"p6":1.62,"year":2015},
+      {"country":"United Kingdom","population":66796807.0,"avg_hh":2.27,"households":29486179.0,"p1":33.01,"p23":46.41,"p45":18.54,"p6":2.04,"year":2011},
+      {"country":"Italy","population":59554023.0,"avg_hh":2.4,"households":24814195.0,"p1":31.1,"p23":43.26,"p45":23.68,"p6":1.96,"year":2011},
+      {"country":"South Africa","population":59308690.0,"avg_hh":3.36,"households":17668822.0,"p1":23.84,"p23":38.77,"p45":26.15,"p6":11.24,"year":2011},
+      {"country":"Tanzania","population":55155000.0,"avg_hh":4.85,"households":11362988.0,"p1":4.43,"p23":25.0,"p45":35.97,"p6":34.6,"year":2016},
+      {"country":"Myanmar","population":51419420.0,"avg_hh":4.22,"households":12186518.0,"p1":12.0,"p23":27.0,"p45":38.99,"p6":22.01,"year":2014},
+      {"country":"South Korea","population":51583722.0,"avg_hh":2.18,"households":23650555.0,"p1":40.81,"p23":40.98,"p45":17.36,"p6":0.85,"year":2022}
+    ];
+
+    const labelCountries = new Set([
+      "China",
+      "India",
+      "United States",
+      "Japan",
+      "Germany",
+      "Pakistan",
+      "Nigeria",
+      "Indonesia",
+      "South Korea"
+    ]);
+
+    const labelPositions = {
+      "China": { ax: 70, ay: -32 },
+      "India": { ax: -80, ay: 36 },
+      "United States": { ax: 68, ay: -18 },
+      "Japan": { ax: 66, ay: -8 },
+      "Germany": { ax: 66, ay: -24 },
+      "Pakistan": { ax: 76, ay: -12 },
+      "Nigeria": { ax: 70, ay: -6 },
+      "Indonesia": { ax: 70, ay: -18 },
+      "South Korea": { ax: 72, ay: 6 }
+    };
+
+    const trace = {
+      type: "scatter",
+      mode: "markers",
+      x: rows.map((d) => d.population),
+      y: rows.map((d) => d.households),
+      hovertext: rows.map((d) => d.country),
+      customdata: rows.map((d) => [d.avg_hh, d.p1, d.p23, d.p45, d.p6, d.year]),
+      marker: {
+        size: rows.map((d) => 10 + d.avg_hh * 2.2),
+        color: rows.map((d) => d.avg_hh),
+        colorscale: [
+          [0, "#4E79A7"],
+          [0.5, "#7DBB73"],
+          [1, "#F28E2B"]
+        ],
+        cmin: 2,
+        cmax: 7,
+        colorbar: {
+          title: { text: "Avg people<br>per household" },
+          thickness: 14,
+          len: 0.72,
+          y: 0.52,
+          outlinewidth: 0
+        },
+        line: { color: "#ffffff", width: 1.5 },
+        opacity: 0.9
+      },
+      hovertemplate:
+        "<b>%{hovertext}</b><br>" +
+        "Population: %{x:,.0f}<br>" +
+        "Households: %{y:,.0f}<br>" +
+        "Avg household size: %{customdata[0]:.2f}<br>" +
+        "1 member: %{customdata[1]:.1f}%<br>" +
+        "2-3 members: %{customdata[2]:.1f}%<br>" +
+        "4-5 members: %{customdata[3]:.1f}%<br>" +
+        "6+ members: %{customdata[4]:.1f}%<br>" +
+        "Year: %{customdata[5]}<extra></extra>"
+    };
+
+    const annotations = [
+      {
+        x: 1.42e9,
+        y: 4.82e8,
+        xref: "x",
+        yref: "y",
+        text: "China has far more households<br>than India despite similar population",
+        showarrow: true,
+        arrowcolor: "#4E79A7",
+        ax: -135,
+        ay: -40,
+        bgcolor: "rgba(255,255,255,0.95)",
+        bordercolor: "rgba(78,121,167,0.22)",
+        borderwidth: 1,
+        font: { size: 13, color: "#244B6D" },
+        align: "left"
+      },
+      {
+        x: 8.31e7,
+        y: 4.06e7,
+        xref: "x",
+        yref: "y",
+        text: "Small-household countries sit higher<br>for the same population size",
+        showarrow: true,
+        arrowcolor: "#4E79A7",
+        ax: 120,
+        ay: -58,
+        bgcolor: "rgba(255,255,255,0.95)",
+        bordercolor: "rgba(78,121,167,0.22)",
+        borderwidth: 1,
+        font: { size: 13, color: "#244B6D" },
+        align: "left"
+      },
+      ...rows
+        .filter((d) => labelCountries.has(d.country))
+        .map((d) => ({
+          x: d.population,
+          y: d.households,
+          xref: "x",
+          yref: "y",
+          text: d.country,
+          showarrow: true,
+          arrowhead: 0,
+          arrowsize: 1,
+          arrowwidth: 1,
+          arrowcolor: "#A0A8B7",
+          ax: labelPositions[d.country].ax,
+          ay: labelPositions[d.country].ay,
+          bgcolor: "rgba(255,255,255,0.94)",
+          bordercolor: "rgba(160,168,183,0.28)",
+          borderwidth: 1,
+          borderpad: 3,
+          font: { size: 12, color: "#111111" },
+          align: "left"
+        }))
+    ];
+
+    const layout = {
+      paper_bgcolor: "#ffffff",
+      plot_bgcolor: "#ffffff",
+      font: {
+        family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+        color: "#222222",
+        size: 16
+      },
+      margin: { l: 90, r: 90, t: 20, b: 85 },
+      xaxis: {
+        type: "log",
+        title: { text: "Current population (log scale)", standoff: 18 },
+        showgrid: true,
+        gridcolor: "#E4E8EE",
+        zeroline: false,
+        automargin: true
+      },
+      yaxis: {
+        type: "log",
+        title: { text: "Number of households (log scale)", standoff: 18 },
+        showgrid: true,
+        gridcolor: "#E4E8EE",
+        zeroline: false,
+        automargin: true
+      },
+      annotations
+    };
+
+    Plotly.newPlot("chart", [trace], layout, {
+      responsive: true,
+      displayModeBar: false
+    });
+
+    window.addEventListener("load", reportHeight);
+    window.addEventListener("resize", reportHeight);
+    setTimeout(reportHeight, 300);
+    setTimeout(reportHeight, 1000);
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-india-china-dumbbell/index.html
+++ b/assets/viz/weekly-india-china-dumbbell/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>China Usually Costs More, But Not Always</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      --bg: #fcfbf7;
+      --text: #171717;
+      --muted: #626262;
+      --grid: #e6e0d8;
+      --china: #c65a3a;
+      --india: #1f7a72;
+      --line: #b8aca0;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .wrap {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 22px 18px 10px;
+    }
+
+    .chart-header {
+      margin-bottom: 10px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 34px;
+      line-height: 1.08;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .chart-subtitle,
+    .chart-note,
+    .source {
+      max-width: 980px;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.45;
+      color: #303030;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: var(--muted);
+    }
+
+    #chart {
+      width: 100%;
+      height: 920px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    @media (max-width: 760px) {
+      .wrap {
+        padding: 16px 12px 8px;
+      }
+
+      .chart-title {
+        font-size: 28px;
+      }
+
+      .chart-subtitle {
+        font-size: 16px;
+      }
+
+      .chart-note,
+      .source {
+        font-size: 14px;
+      }
+
+      #chart {
+        height: 980px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="chart-header">
+      <h1 class="chart-title">
+        China Usually Costs <span style="color: var(--china);">More</span>, But Not Always
+      </h1>
+      <p class="chart-subtitle">
+        Across 20 cost items in the dataset, China is pricier on 17, especially rent, fitness memberships, and mobile plans. India runs higher on only three: cappuccino, draft beer, and cigarettes.
+      </p>
+      <p class="chart-note">
+        Each row shows the same item in both countries. Salary is excluded here because it is income, not a living cost. The chart is sorted by the China-to-India price ratio, and the x-axis uses a log scale so high-ticket items and small daily purchases can share one view.
+      </p>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Source: user-provided CSV comparing listed China and India costs in USD. Caveat: the file does not include a source citation or reference date, so values should be read as a snapshot rather than a current market benchmark.
+    </div>
+  </div>
+
+  <script>
+    function reportHeight() {
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const rows = [
+      { item: "Monthly Fitness Club Membership", china: 41.25, india: 14.75, ratio: 2.8, delta: 26.5, direction: "China higher" },
+      { item: "Milk (1 gallon)", china: 6.86, india: 2.5, ratio: 2.74, delta: 4.36, direction: "China higher" },
+      { item: "Monthly Rent, 1-bedroom in city center", china: 405.0, india: 151.0, ratio: 2.68, delta: 254.0, direction: "China higher" },
+      { item: "Monthly Mobile Phone Plan", china: 8.74, india: 3.64, ratio: 2.4, delta: 5.1, direction: "China higher" },
+      { item: "Movie Ticket (International Release)", china: 6.55, india: 3.23, ratio: 2.03, delta: 3.32, direction: "China higher" },
+      { item: "Dozen Eggs", china: 1.59, india: 0.91, ratio: 1.75, delta: 0.68, direction: "China higher" },
+      { item: "Bottled Water (12 oz)", china: 0.28, india: 0.16, ratio: 1.75, delta: 0.12, direction: "China higher" },
+      { item: "Bottle of Wine (Mid-Range)", china: 11.64, india: 7.62, ratio: 1.53, delta: 4.02, direction: "China higher" },
+      { item: "Monthly Broadband Internet", china: 11.02, india: 7.26, ratio: 1.52, delta: 3.76, direction: "China higher" },
+      { item: "New Compact Car", china: 18903.0, india: 12933.0, ratio: 1.46, delta: 5970.0, direction: "China higher" },
+      { item: "White Rice (1 lb)", china: 0.43, india: 0.3, ratio: 1.43, delta: 0.13, direction: "China higher" },
+      { item: "Monthly Basic Utilities", china: 52.48, india: 38.73, ratio: 1.36, delta: 13.75, direction: "China higher" },
+      { item: "Meal at an Inexpensive Restaurant", china: 2.91, india: 2.16, ratio: 1.35, delta: 0.75, direction: "China higher" },
+      { item: "Combo Meal McDonald’s", china: 5.09, india: 3.77, ratio: 1.35, delta: 1.32, direction: "China higher" },
+      { item: "Soft Drink (Coca-Cola or Pepsi, 12 oz)", china: 0.48, india: 0.41, ratio: 1.17, delta: 0.07, direction: "China higher" },
+      { item: "Local Transport 1-Way Ticket", china: 0.29, india: 0.27, ratio: 1.07, delta: 0.02, direction: "China higher" },
+      { item: "Gasoline (1 gallon)", china: 4.32, india: 4.17, ratio: 1.04, delta: 0.15, direction: "China higher" },
+      { item: "Pack of Cigarettes", china: 3.64, india: 3.77, ratio: 0.97, delta: -0.13, direction: "India higher" },
+      { item: "Cappuccino (Regular size)", china: 1.74, india: 2.95, ratio: 0.59, delta: -1.21, direction: "India higher" },
+      { item: "Pint of Beer (Domestic Draft)", china: 1.02, india: 1.89, ratio: 0.54, delta: -0.87, direction: "India higher" }
+    ];
+
+    const categories = rows.map((d) => d.item);
+    const lineTraces = rows.map((d) => ({
+      type: "scatter",
+      mode: "lines",
+      x: [d.india, d.china],
+      y: [d.item, d.item],
+      hoverinfo: "skip",
+      line: {
+        color: d.direction === "India higher" ? "rgba(31,122,114,0.4)" : "rgba(184,172,160,0.95)",
+        width: 3
+      },
+      showlegend: false
+    }));
+
+    const chinaTrace = {
+      type: "scatter",
+      mode: "markers",
+      name: "China",
+      x: rows.map((d) => d.china),
+      y: categories,
+      customdata: rows.map((d) => [d.india, d.ratio, d.delta, d.direction]),
+      marker: {
+        color: "#c65a3a",
+        size: 13,
+        line: { color: "#fcfbf7", width: 1.6 }
+      },
+      hovertemplate:
+        "<b>%{y}</b><br>" +
+        "China: $%{x:,.2f}<br>" +
+        "India: $%{customdata[0]:,.2f}<br>" +
+        "China / India: %{customdata[1]:.2f}x<br>" +
+        "Gap: $%{customdata[2]:,.2f}<br>" +
+        "%{customdata[3]}<extra></extra>"
+    };
+
+    const indiaTrace = {
+      type: "scatter",
+      mode: "markers",
+      name: "India",
+      x: rows.map((d) => d.india),
+      y: categories,
+      customdata: rows.map((d) => [d.china, d.ratio, d.delta, d.direction]),
+      marker: {
+        color: "#1f7a72",
+        size: 13,
+        symbol: "diamond",
+        line: { color: "#fcfbf7", width: 1.6 }
+      },
+      hovertemplate:
+        "<b>%{y}</b><br>" +
+        "India: $%{x:,.2f}<br>" +
+        "China: $%{customdata[0]:,.2f}<br>" +
+        "China / India: %{customdata[1]:.2f}x<br>" +
+        "Gap: $%{customdata[2]:,.2f}<br>" +
+        "%{customdata[3]}<extra></extra>"
+    };
+
+    const layout = {
+      paper_bgcolor: "#fcfbf7",
+      plot_bgcolor: "#fcfbf7",
+      font: { family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif", color: "#222222", size: 14 },
+      margin: { l: 230, r: 60, t: 10, b: 70 },
+      hovermode: "closest",
+      showlegend: true,
+      legend: {
+        orientation: "h",
+        x: 0,
+        y: 1.08,
+        xanchor: "left",
+        yanchor: "bottom",
+        bgcolor: "rgba(252,251,247,0.9)",
+        font: { size: 13 }
+      },
+      xaxis: {
+        type: "log",
+        range: [-1.05, 4.45],
+        tickvals: [0.2, 0.5, 1, 2, 5, 10, 50, 500, 5000, 20000],
+        ticktext: ["$0.20", "$0.50", "$1", "$2", "$5", "$10", "$50", "$500", "$5k", "$20k"],
+        showgrid: true,
+        gridcolor: "#e6e0d8",
+        zeroline: false,
+        title: { text: "Cost in USD (log scale)", standoff: 16 }
+      },
+      yaxis: {
+        categoryorder: "array",
+        categoryarray: categories.slice().reverse(),
+        automargin: true,
+        tickfont: { size: 12 },
+        showgrid: false
+      },
+      annotations: [
+        {
+          xref: "paper",
+          yref: "paper",
+          x: 0.99,
+          y: 1.02,
+          text: "China higher on 17 of 20 cost items",
+          showarrow: false,
+          xanchor: "right",
+          font: { size: 13, color: "#6a4a3b" },
+          bgcolor: "rgba(198,90,58,0.08)",
+          bordercolor: "rgba(198,90,58,0.22)",
+          borderwidth: 1,
+          borderpad: 6
+        },
+        {
+          x: 405,
+          y: "Monthly Rent, 1-bedroom in city center",
+          text: "Rent is 2.7x higher in China",
+          showarrow: true,
+          arrowcolor: "#c65a3a",
+          ax: 120,
+          ay: -34,
+          bgcolor: "rgba(252,251,247,0.95)",
+          bordercolor: "rgba(198,90,58,0.2)",
+          borderwidth: 1,
+          font: { size: 12, color: "#6a3a29" },
+          align: "left"
+        },
+        {
+          x: 2.95,
+          y: "Cappuccino (Regular size)",
+          text: "India is higher on a few<br>small consumer items",
+          showarrow: true,
+          arrowcolor: "#1f7a72",
+          ax: 96,
+          ay: -38,
+          bgcolor: "rgba(252,251,247,0.95)",
+          bordercolor: "rgba(31,122,114,0.2)",
+          borderwidth: 1,
+          font: { size: 12, color: "#13564f" },
+          align: "left"
+        }
+      ]
+    };
+
+    const config = {
+      responsive: true,
+      displayModeBar: false
+    };
+
+    Plotly.newPlot("chart", [...lineTraces, chinaTrace, indiaTrace], layout, config).then(() => {
+      reportHeight();
+      window.addEventListener("resize", reportHeight);
+      setTimeout(reportHeight, 120);
+    });
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-restaurant-marketcap-ranking/index.html
+++ b/assets/viz/weekly-restaurant-marketcap-ranking/index.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>McDonald Towers Over Public Restaurant Chains</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      --bg: #fcfbf7;
+      --text: #171717;
+      --muted: #666666;
+      --grid: #e6e0d8;
+      --accent: #bf4f2f;
+      --bar: #c8beb3;
+      --bar-soft: #ddd6cf;
+      --note: #7b4e3f;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .wrap {
+      max-width: 1060px;
+      margin: 0 auto;
+      padding: 22px 18px 10px;
+    }
+
+    .chart-header {
+      margin-bottom: 10px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 34px;
+      line-height: 1.08;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .chart-subtitle,
+    .chart-note,
+    .source {
+      max-width: 980px;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.45;
+      color: #2f2f2f;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: var(--muted);
+    }
+
+    #chart {
+      width: 100%;
+      height: 760px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    .source a {
+      color: #2569a8;
+    }
+
+    @media (max-width: 760px) {
+      .wrap {
+        padding: 16px 12px 8px;
+      }
+
+      .chart-title {
+        font-size: 28px;
+      }
+
+      .chart-subtitle {
+        font-size: 16px;
+      }
+
+      .chart-note,
+      .source {
+        font-size: 14px;
+      }
+
+      #chart {
+        height: 860px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="chart-header">
+      <h1 class="chart-title">
+        McDonald <span style="color: var(--accent);">Towers Over</span> Public Restaurant Chains
+      </h1>
+      <p class="chart-subtitle">
+        In this snapshot of 63 listed restaurant companies, McDonald alone accounts for roughly 45% of the combined market value. The top 10 chains make up about 85%.
+      </p>
+      <p class="chart-note">
+        This view shows the top 15 companies by market cap. Share price is not used as the main comparison because it is not a company-size metric; exact market cap, ticker, and country appear in hover.
+      </p>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Source:
+      <a href="https://companiesmarketcap.com/restaurant-chains/largest-restaurant-chain-companies-by-market-cap/#google_vignette" target="_blank" rel="noreferrer">CompaniesMarketCap, largest restaurant chains by market cap</a>.
+      Caveat: treat this as a market-cap snapshot rather than a stable long-run ranking.
+    </div>
+  </div>
+
+  <script>
+    function reportHeight() {
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const rows = [
+      { rank: 1, name: "McDonald", symbol: "MCD", marketcap_b: 232.96, price_usd: 326.46, country: "United States" },
+      { rank: 2, name: "Yum! Brands", symbol: "YUM", marketcap_b: 44.54, price_usd: 160.4, country: "United States" },
+      { rank: 3, name: "Chipotle Mexican Grill", symbol: "CMG", marketcap_b: 43.0, price_usd: 32.52, country: "United States" },
+      { rank: 4, name: "Restaurant Brands International", symbol: "QSR", marketcap_b: 33.12, price_usd: 72.65, country: "Canada" },
+      { rank: 5, name: "Darden Restaurants", symbol: "DRI", marketcap_b: 23.54, price_usd: 202.37, country: "United States" },
+      { rank: 6, name: "Yum China", symbol: "YUMC", marketcap_b: 18.58, price_usd: 52.7, country: "China" },
+      { rank: 7, name: "Domino's Pizza", symbol: "DPZ", marketcap_b: 13.51, price_usd: 401.62, country: "United States" },
+      { rank: 8, name: "Texas Roadhouse", symbol: "TXRH", marketcap_b: 11.26, price_usd: 170.24, country: "United States" },
+      { rank: 9, name: "Hai Di Lao Hot Pot", symbol: "6862.HK", marketcap_b: 11.08, price_usd: 2.05, country: "China" },
+      { rank: 10, name: "CAVA Group", symbol: "CAVA", marketcap_b: 9.54, price_usd: 82.0, country: "United States" },
+      { rank: 11, name: "Zensho Holdings", symbol: "7550.T", marketcap_b: 9.37, price_usd: 59.89, country: "Japan" },
+      { rank: 12, name: "Food & Life Companies", symbol: "3563.T", marketcap_b: 6.84, price_usd: 60.4, country: "Japan" },
+      { rank: 13, name: "McDonald's Japan", symbol: "2702.T", marketcap_b: 6.51, price_usd: 48.99, country: "Japan" },
+      { rank: 14, name: "Brinker International", symbol: "EAT", marketcap_b: 6.4, price_usd: 144.02, country: "United States" },
+      { rank: 15, name: "Wingstop Restaurants", symbol: "WING", marketcap_b: 5.65, price_usd: 203.44, country: "United States" }
+    ];
+
+    const labels = rows.map((d) => `${d.rank}. ${d.name}`);
+    const values = rows.map((d) => d.marketcap_b);
+    const colors = rows.map((d) => (d.name === "McDonald" ? "#bf4f2f" : "#c8beb3"));
+    const textColors = rows.map((d) => (d.name === "McDonald" ? "#8d3922" : "#5f5b55"));
+
+    const trace = {
+      type: "bar",
+      orientation: "h",
+      x: values.slice().reverse(),
+      y: labels.slice().reverse(),
+      marker: {
+        color: colors.slice().reverse(),
+        line: {
+          color: "#f7f2ec",
+          width: 1
+        }
+      },
+      customdata: rows.map((d) => [d.symbol, d.country, d.price_usd]).reverse(),
+      text: values.map((d) => `$${d.toFixed(1)}B`).reverse(),
+      textposition: "outside",
+      cliponaxis: false,
+      hovertemplate:
+        "<b>%{y}</b><br>" +
+        "Market cap: %{x:.2f}B USD<br>" +
+        "Ticker: %{customdata[0]}<br>" +
+        "Country: %{customdata[1]}<br>" +
+        "Share price: $%{customdata[2]:,.2f}<extra></extra>"
+    };
+
+    const layout = {
+      paper_bgcolor: "#fcfbf7",
+      plot_bgcolor: "#fcfbf7",
+      font: {
+        family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+        color: "#222222",
+        size: 14
+      },
+      margin: { l: 250, r: 90, t: 54, b: 52 },
+      xaxis: {
+        title: { text: "Market cap (USD billions)", standoff: 14 },
+        showgrid: true,
+        gridcolor: "#e6e0d8",
+        zeroline: false,
+        tickprefix: "$",
+        ticksuffix: "B"
+      },
+      yaxis: {
+        automargin: true,
+        tickfont: { size: 12 },
+        showgrid: false
+      },
+      bargap: 0.22,
+      showlegend: false,
+      annotations: [
+        {
+          xref: "paper",
+          yref: "paper",
+          x: 0.56,
+          y: 1.08,
+          xanchor: "left",
+          text: "Top 15 hold 91% of the file's total market cap",
+          showarrow: false,
+          font: { size: 13, color: "#7b4e3f" },
+          bgcolor: "rgba(191,79,47,0.08)",
+          bordercolor: "rgba(191,79,47,0.2)",
+          borderwidth: 1,
+          borderpad: 6
+        },
+        {
+          x: 232.96,
+          y: "1. McDonald",
+          text: "McDonald alone is nearly<br>5x the size of No. 2",
+          showarrow: true,
+          arrowcolor: "#bf4f2f",
+          ax: -126,
+          ay: -8,
+          bgcolor: "rgba(252,251,247,0.96)",
+          bordercolor: "rgba(191,79,47,0.2)",
+          borderwidth: 1,
+          font: { size: 12, color: "#7b3b28" },
+          align: "left"
+        },
+        {
+          x: 18.58,
+          y: "6. Yum China",
+          text: "After the first five,<br>the tier drops sharply",
+          showarrow: true,
+          arrowcolor: "#96887d",
+          ax: 104,
+          ay: 22,
+          bgcolor: "rgba(252,251,247,0.96)",
+          bordercolor: "rgba(150,136,125,0.24)",
+          borderwidth: 1,
+          font: { size: 12, color: "#59514a" },
+          align: "left"
+        }
+      ]
+    };
+
+    const config = {
+      responsive: true,
+      displayModeBar: false
+    };
+
+    Plotly.newPlot("chart", [trace], layout, config).then(() => {
+      reportHeight();
+      window.addEventListener("resize", reportHeight);
+      setTimeout(reportHeight, 120);
+    });
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-state-jobs-sankey/index.html
+++ b/assets/viz/weekly-state-jobs-sankey/index.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>One Job Owns the No. 1 Slot Across Almost Every State</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      --bg: #fcfbf7;
+      --text: #171717;
+      --muted: #666666;
+      --grid: #e6e0d8;
+      --link: #2569a8;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .wrap {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 22px 18px 10px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 34px;
+      line-height: 1.08;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .chart-subtitle,
+    .chart-note,
+    .source {
+      max-width: 980px;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.45;
+      color: #2f2f2f;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: var(--muted);
+    }
+
+    #chart {
+      width: 100%;
+      height: 880px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    .source a {
+      color: var(--link);
+    }
+
+    @media (max-width: 760px) {
+      .wrap {
+        padding: 16px 12px 8px;
+      }
+
+      .chart-title {
+        font-size: 28px;
+      }
+
+      .chart-subtitle {
+        font-size: 16px;
+      }
+
+      .chart-note,
+      .source {
+        font-size: 14px;
+      }
+
+      #chart {
+        height: 980px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1 class="chart-title">
+      One Job Owns the No. 1 Slot Across <span style="color:#c65a3a;">Almost Every</span> State
+    </h1>
+    <p class="chart-subtitle">
+      Lightcast's state-by-state ranking is overwhelmingly led by one title: Registered Nurse is the most-posted job in 49 of 50 states. Lower down the ladder, Retail Sales Associate dominates the second slot, while Truck Driver and Physician titles recur most often at third.
+    </p>
+    <p class="chart-note">
+      This is a rank chart, not a posting-volume chart. Each link shows how many states share the same sequence from the 1st most-posted title to the 2nd and 3rd, based on the Lightcast article's state rankings from October 2024 to October 2025.
+    </p>
+    <div id="chart"></div>
+    <div class="source">
+      Source:
+      <a href="https://lightcast.io/resources/blog/most-posted-for-jobs-in-each-us-state" target="_blank" rel="noreferrer">Lightcast, "Job titles in highest-demand, state by state"</a>.
+      Data used here was extracted from the article's embedded state-by-state ranking visualization.
+    </div>
+  </div>
+
+  <script>
+    function reportHeight() {
+      const height = Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const rows = [
+      { state: "Alabama", abbr: "AL", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Retail Sales Associate" },
+      { state: "Alaska", abbr: "AK", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Physician" },
+      { state: "Arizona", abbr: "AZ", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Physician" },
+      { state: "Arkansas", abbr: "AR", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Retail Sales Associate" },
+      { state: "California", abbr: "CA", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Sales Representative" },
+      { state: "Colorado", abbr: "CO", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Connecticut", abbr: "CT", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Physician" },
+      { state: "Delaware", abbr: "DE", rank1: "Registered Nurse", rank2: "Software Developer / Engineer", rank3: "Retail Sales Associate" },
+      { state: "Florida", abbr: "FL", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Physician" },
+      { state: "Georgia", abbr: "GA", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Hawaii", abbr: "HI", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Customer Service Representative" },
+      { state: "Idaho", abbr: "ID", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Illinois", abbr: "IL", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Indiana", abbr: "IN", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Retail Sales Associate" },
+      { state: "Iowa", abbr: "IA", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Physician" },
+      { state: "Kansas", abbr: "KS", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Kentucky", abbr: "KY", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Retail Sales Associate" },
+      { state: "Louisiana", abbr: "LA", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Retail Store Manager / Supervisor" },
+      { state: "Maine", abbr: "ME", rank1: "Registered Nurse", rank2: "Physician", rank3: "Retail Sales Associate" },
+      { state: "Maryland", abbr: "MD", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Software Developer / Engineer" },
+      { state: "Massachusetts", abbr: "MA", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Software Developer / Engineer" },
+      { state: "Michigan", abbr: "MI", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Minnesota", abbr: "MN", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Mississippi", abbr: "MS", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Retail Sales Associate" },
+      { state: "Missouri", abbr: "MO", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Montana", abbr: "MT", rank1: "Registered Nurse", rank2: "Physician", rank3: "Retail Sales Associate" },
+      { state: "Nebraska", abbr: "NE", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Retail Sales Associate" },
+      { state: "Nevada", abbr: "NV", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Sales Representative" },
+      { state: "New Hampshire", abbr: "NH", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Physician" },
+      { state: "New Jersey", abbr: "NJ", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Software Developer / Engineer" },
+      { state: "New Mexico", abbr: "NM", rank1: "Registered Nurse", rank2: "Physician", rank3: "Retail Sales Associate" },
+      { state: "New York", abbr: "NY", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Physician" },
+      { state: "North Carolina", abbr: "NC", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "North Dakota", abbr: "ND", rank1: "Registered Nurse", rank2: "Physician", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Ohio", abbr: "OH", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Retail Sales Associate" },
+      { state: "Oklahoma", abbr: "OK", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Oregon", abbr: "OR", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Physician" },
+      { state: "Pennsylvania", abbr: "PA", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Rhode Island", abbr: "RI", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Software Developer / Engineer" },
+      { state: "South Carolina", abbr: "SC", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "South Dakota", abbr: "SD", rank1: "Registered Nurse", rank2: "Physician", rank3: "Licensed Practical / Vocational Nurse" },
+      { state: "Tennessee", abbr: "TN", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Texas", abbr: "TX", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Sales Representative" },
+      { state: "Utah", abbr: "UT", rank1: "Retail Sales Associate", rank2: "Registered Nurse", rank3: "Sales Representative" },
+      { state: "Vermont", abbr: "VT", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Virginia", abbr: "VA", rank1: "Registered Nurse", rank2: "Software Developer / Engineer", rank3: "Retail Sales Associate" },
+      { state: "Washington", abbr: "WA", rank1: "Registered Nurse", rank2: "Retail Sales Associate", rank3: "Physician" },
+      { state: "West Virginia", abbr: "WV", rank1: "Registered Nurse", rank2: "Physician", rank3: "Tractor-Trailer Truck Driver" },
+      { state: "Wisconsin", abbr: "WI", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Retail Sales Associate" },
+      { state: "Wyoming", abbr: "WY", rank1: "Registered Nurse", rank2: "Tractor-Trailer Truck Driver", rank3: "Physician" }
+    ];
+
+    const titleColors = {
+      "Registered Nurse": "#c65a3a",
+      "Retail Sales Associate": "#7a57a8",
+      "Tractor-Trailer Truck Driver": "#d28c2c",
+      "Physician": "#2f7f76",
+      "Software Developer / Engineer": "#3f74b5",
+      "Sales Representative": "#b76b4c",
+      "Customer Service Representative": "#7b7b7b",
+      "Retail Store Manager / Supervisor": "#9c6a4d",
+      "Licensed Practical / Vocational Nurse": "#6d8f5b"
+    };
+
+    const rankConfig = [
+      { key: "rank1", title: "#1 most posted", x: 0.02 },
+      { key: "rank2", title: "#2 most posted", x: 0.50 },
+      { key: "rank3", title: "#3 most posted", x: 0.98 }
+    ];
+
+    const countsByRank = {};
+    rankConfig.forEach((rank) => {
+      countsByRank[rank.key] = {};
+      rows.forEach((row) => {
+        countsByRank[rank.key][row[rank.key]] = (countsByRank[rank.key][row[rank.key]] || 0) + 1;
+      });
+    });
+
+    const displayLabel = (title) =>
+      title
+        .replace("Software Developer / Engineer", "Software Developer<br>/ Engineer")
+        .replace("Tractor-Trailer Truck Driver", "Truck Driver")
+        .replace("Customer Service Representative", "Customer Service<br>Representative")
+        .replace("Retail Store Manager / Supervisor", "Retail Store Manager<br>/ Supervisor")
+        .replace("Licensed Practical / Vocational Nurse", "Licensed Practical<br>/ Vocational Nurse");
+
+    const nodes = [];
+    const nodeLookup = new Map();
+    rankConfig.forEach((rank, rankIndex) => {
+      const entries = Object.entries(countsByRank[rank.key]).sort((a, b) => b[1] - a[1]);
+      entries.forEach(([title, count], idx) => {
+        const states = rows.filter((row) => row[rank.key] === title).map((row) => row.abbr).sort();
+        const label = `${displayLabel(title)}<br>${count} state${count === 1 ? "" : "s"}`;
+        const node = {
+          key: `${rank.key}:${title}`,
+          title,
+          label,
+          count,
+          x: rank.x,
+          y: entries.length === 1 ? 0.5 : 0.08 + (idx / (entries.length - 1)) * 0.84,
+          color: titleColors[title] || "#9a8f83",
+          hover: `${rank.title}<br>${title}<br>${count} state${count === 1 ? "" : "s"}<br>${states.join(", ")}`
+        };
+        nodeLookup.set(node.key, nodes.length);
+        nodes.push(node);
+      });
+    });
+
+    const flowMap = new Map();
+    function addFlow(sourceRank, targetRank) {
+      rows.forEach((row) => {
+        const sourceTitle = row[sourceRank];
+        const targetTitle = row[targetRank];
+        const key = `${sourceRank}:${sourceTitle}|||${targetRank}:${targetTitle}`;
+        if (!flowMap.has(key)) {
+          flowMap.set(key, { sourceRank, targetRank, sourceTitle, targetTitle, states: [] });
+        }
+        flowMap.get(key).states.push(row.abbr);
+      });
+    }
+    addFlow("rank1", "rank2");
+    addFlow("rank2", "rank3");
+
+    const links = Array.from(flowMap.values()).map((flow) => ({
+      source: nodeLookup.get(`${flow.sourceRank}:${flow.sourceTitle}`),
+      target: nodeLookup.get(`${flow.targetRank}:${flow.targetTitle}`),
+      value: flow.states.length,
+      color: titleColors[flow.sourceTitle] ? `${titleColors[flow.sourceTitle]}33` : "rgba(154,143,131,0.25)",
+      hover: `${flow.states.length} state${flow.states.length === 1 ? "" : "s"}<br>${flow.sourceTitle} → ${flow.targetTitle}<br>${flow.states.sort().join(", ")}`
+    }));
+
+    const trace = {
+      type: "sankey",
+      arrangement: "fixed",
+      node: {
+        pad: 18,
+        thickness: 18,
+        line: { color: "#fcfbf7", width: 1.4 },
+        label: nodes.map((d) => d.label),
+        color: nodes.map((d) => d.color),
+        x: nodes.map((d) => d.x),
+        y: nodes.map((d) => d.y),
+        customdata: nodes.map((d) => d.hover),
+        hovertemplate: "%{customdata}<extra></extra>"
+      },
+      link: {
+        source: links.map((d) => d.source),
+        target: links.map((d) => d.target),
+        value: links.map((d) => d.value),
+        color: links.map((d) => d.color),
+        customdata: links.map((d) => d.hover),
+        hovertemplate: "%{customdata}<extra></extra>"
+      }
+    };
+
+    function buildLayout() {
+      const mobile = window.innerWidth <= 760;
+      return {
+        paper_bgcolor: "#fcfbf7",
+        plot_bgcolor: "#fcfbf7",
+        font: {
+          family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+          color: "#222222",
+          size: mobile ? 12 : 13
+        },
+        margin: { l: 20, r: 20, t: 70, b: 80 },
+        annotations: [
+          {
+            xref: "paper",
+            yref: "paper",
+            x: 0.02,
+            y: 1.06,
+            text: "#1 title",
+            showarrow: false,
+            xanchor: "left",
+            font: { size: mobile ? 11 : 12, color: "#6a6a6a" }
+          },
+          {
+            xref: "paper",
+            yref: "paper",
+            x: 0.50,
+            y: 1.06,
+            text: "#2 title",
+            showarrow: false,
+            xanchor: "center",
+            font: { size: mobile ? 11 : 12, color: "#6a6a6a" }
+          },
+          {
+            xref: "paper",
+            yref: "paper",
+            x: 0.98,
+            y: 1.06,
+            text: "#3 title",
+            showarrow: false,
+            xanchor: "right",
+            font: { size: mobile ? 11 : 12, color: "#6a6a6a" }
+          },
+          {
+            xref: "paper",
+            yref: "paper",
+            x: 0,
+            y: -0.09,
+            xanchor: "left",
+            yanchor: "top",
+            showarrow: false,
+            align: "left",
+            font: { size: mobile ? 11 : 12, color: "#6b6b6b" },
+            text: "Chart summary: one title dominates the top slot almost everywhere, then state rankings fan out into retail, trucking, physician, and software roles."
+          }
+        ]
+      };
+    }
+
+    function render() {
+      Plotly.newPlot("chart", [trace], buildLayout(), {
+        responsive: true,
+        displayModeBar: false
+      }).then(reportHeight);
+    }
+
+    render();
+    window.addEventListener("resize", () => {
+      Plotly.react("chart", [trace], buildLayout(), {
+        responsive: true,
+        displayModeBar: false
+      }).then(reportHeight);
+    });
+    window.addEventListener("load", reportHeight);
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-top1-wealth-dumbbell/index.html
+++ b/assets/viz/weekly-top1-wealth-dumbbell/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Top 1% Live in a Different Wealth Universe</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      --bg: #fcfbf7;
+      --text: #171717;
+      --muted: #666666;
+      --grid: #e6e0d8;
+      --line: #cfc4b8;
+      --top: #c65a3a;
+      --bottom: #6d8da4;
+      --link: #2569a8;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .wrap {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 22px 18px 10px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 35px;
+      line-height: 1.08;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .chart-subtitle,
+    .chart-note,
+    .source {
+      max-width: 980px;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.45;
+      color: #2f2f2f;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: var(--muted);
+    }
+
+    .legend-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      align-items: center;
+      margin-bottom: 8px;
+      font-size: 14px;
+      color: #4b4b4b;
+    }
+
+    .legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .legend-swatch {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      display: inline-block;
+    }
+
+    #chart {
+      width: 100%;
+      height: 760px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    .source a {
+      color: var(--link);
+    }
+
+    @media (max-width: 760px) {
+      .wrap {
+        padding: 16px 12px 8px;
+      }
+
+      .chart-title {
+        font-size: 29px;
+      }
+
+      .chart-subtitle {
+        font-size: 16px;
+      }
+
+      .chart-note,
+      .legend-row,
+      .source {
+        font-size: 14px;
+      }
+
+      #chart {
+        height: 860px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1 class="chart-title">
+      The Top 1% Live in a <span style="color: var(--top);">Different</span> Wealth Universe
+    </h1>
+    <p class="chart-subtitle">
+      Across 11 major economies, the average member of the top 1% holds millions in PPP-adjusted wealth, while the average person in the bottom half often holds only tens of thousands or less. The U.S. sits farthest right in absolute wealth, while Mexico has the highest top-1% share.
+    </p>
+    <p class="chart-note">
+      Each dumbbell compares two like-for-like per-capita wealth measures within a country: the bottom 50% and the top 1%. Country labels show the top 1% share of national wealth. The x-axis uses a log scale because the lower-half values are in thousands while the top-end values are in millions.
+    </p>
+    <div class="legend-row" aria-label="Dumbbell legend">
+      <span class="legend-item"><span class="legend-swatch" style="background:#6d8da4"></span>Bottom 50% average wealth</span>
+      <span class="legend-item"><span class="legend-swatch" style="background:#c65a3a"></span>Top 1% average wealth</span>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Source:
+      <a href="https://www.visualcapitalist.com/wealth-of-the-top-1-across-major-economies/" target="_blank" rel="noreferrer">Visual Capitalist, "How Wealthy the Top 1% Are in Each Major Economy"</a>,
+      using McKinsey data cited in the article.
+    </div>
+  </div>
+
+  <script>
+    function reportHeight() {
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const rows = [
+      { country: "U.S.", top1: 16400000, bottom50: 9000, share: 35 },
+      { country: "Australia", top1: 10600000, bottom50: 36000, share: 24 },
+      { country: "Canada", top1: 9100000, bottom50: 30000, share: 24 },
+      { country: "Germany", top1: 9100000, bottom50: 23000, share: 28 },
+      { country: "France", top1: 8500000, bottom50: 31000, share: 27 },
+      { country: "Italy", top1: 7200000, bottom50: 17000, share: 22 },
+      { country: "South Korea", top1: 7200000, bottom50: 10000, share: 26 },
+      { country: "Japan", top1: 6900000, bottom50: 22000, share: 25 },
+      { country: "UK", top1: 5000000, bottom50: 22000, share: 21 },
+      { country: "China", top1: 3200000, bottom50: 13000, share: 30 },
+      { country: "Mexico", top1: 2700000, bottom50: 3000, share: 37 }
+    ];
+
+    function wealthLabel(value) {
+      if (value >= 1000000) return "$" + (value / 1000000).toFixed(1) + "M";
+      return "$" + Math.round(value / 1000) + "K";
+    }
+
+    const sorted = rows.slice().sort((a, b) => b.top1 - a.top1);
+    const categories = sorted.map((d, i) => `${i + 1}. ${d.country} (${d.share}%)`);
+
+    const lineTraces = sorted.map((d, i) => ({
+      type: "scatter",
+      mode: "lines",
+      x: [d.bottom50, d.top1],
+      y: [categories[i], categories[i]],
+      hoverinfo: "skip",
+      line: {
+        color: "rgba(207,196,184,0.95)",
+        width: 4
+      },
+      showlegend: false
+    }));
+
+    const bottomTrace = {
+      type: "scatter",
+      mode: "markers",
+      name: "Bottom 50%",
+      x: sorted.map((d) => d.bottom50),
+      y: categories,
+      customdata: sorted.map((d) => [d.country, d.top1, d.share, d.top1 / d.bottom50]),
+      marker: {
+        color: "#6d8da4",
+        size: 12,
+        line: { color: "#fcfbf7", width: 1.6 }
+      },
+      hovertemplate:
+        "<b>%{customdata[0]}</b><br>" +
+        "Bottom 50% average wealth: %{x:$,.0f}<br>" +
+        "Top 1% average wealth: %{customdata[1]:$,.0f}<br>" +
+        "Top 1% share of wealth: %{customdata[2]}%<br>" +
+        "Top / bottom ratio: %{customdata[3]:,.0f}x<extra></extra>"
+    };
+
+    const topTrace = {
+      type: "scatter",
+      mode: "markers+text",
+      name: "Top 1%",
+      x: sorted.map((d) => d.top1),
+      y: categories,
+      text: sorted.map((d) => wealthLabel(d.top1)),
+      textposition: "middle right",
+      textfont: {
+        size: 13,
+        color: "#7a4b37"
+      },
+      cliponaxis: false,
+      customdata: sorted.map((d) => [d.country, d.bottom50, d.share, d.top1 / d.bottom50]),
+      marker: {
+        color: "#c65a3a",
+        size: 14,
+        line: { color: "#fcfbf7", width: 1.8 }
+      },
+      hovertemplate:
+        "<b>%{customdata[0]}</b><br>" +
+        "Top 1% average wealth: %{x:$,.0f}<br>" +
+        "Bottom 50% average wealth: %{customdata[1]:$,.0f}<br>" +
+        "Top 1% share of wealth: %{customdata[2]}%<br>" +
+        "Top / bottom ratio: %{customdata[3]:,.0f}x<extra></extra>"
+    };
+
+    function buildLayout() {
+      const mobile = window.innerWidth <= 760;
+      return {
+        paper_bgcolor: "#fcfbf7",
+        plot_bgcolor: "#fcfbf7",
+        font: {
+          family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+          color: "#222222",
+          size: mobile ? 13 : 14
+        },
+        margin: {
+          l: mobile ? 132 : 180,
+          r: mobile ? 92 : 132,
+          t: 8,
+          b: 52
+        },
+        hovermode: "closest",
+        showlegend: false,
+        xaxis: {
+          type: "log",
+          range: [3.35, 7.35],
+          tickvals: [3000, 10000, 30000, 100000, 1000000, 3000000, 10000000],
+          ticktext: ["$3K", "$10K", "$30K", "$100K", "$1M", "$3M", "$10M"],
+          showgrid: true,
+          gridcolor: "#e6e0d8",
+          zeroline: false,
+          title: {
+            text: "Average per-capita wealth (PPP-adjusted, log scale)",
+            standoff: 16
+          }
+        },
+        yaxis: {
+          categoryorder: "array",
+          categoryarray: categories.slice().reverse(),
+          automargin: true,
+          tickfont: { size: mobile ? 11 : 12 },
+          showgrid: false
+        },
+        annotations: [
+          {
+            xref: "paper",
+            yref: "paper",
+            x: 0,
+            y: -0.14,
+            xanchor: "left",
+            yanchor: "top",
+            align: "left",
+            showarrow: false,
+            font: { size: mobile ? 11 : 12, color: "#6b6b6b" },
+            text: "Note: label parentheses show the top 1%'s share of national wealth."
+          }
+        ]
+      };
+    }
+
+    function render() {
+      Plotly.newPlot(
+        "chart",
+        [...lineTraces, bottomTrace, topTrace],
+        buildLayout(),
+        { displayModeBar: false, responsive: true }
+      ).then(reportHeight);
+    }
+
+    render();
+    window.addEventListener("resize", () => {
+      Plotly.react("chart", [...lineTraces, bottomTrace, topTrace], buildLayout(), {
+        displayModeBar: false,
+        responsive: true
+      }).then(reportHeight);
+    });
+    window.addEventListener("load", reportHeight);
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-world-cities-bump/index.html
+++ b/assets/viz/weekly-world-cities-bump/index.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Urban Order Is Tilting Toward Asia and Africa</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    :root {
+      --bg: #fcfbf7;
+      --text: #171717;
+      --muted: #666666;
+      --grid: #e6e0d8;
+      --line: #d1c8bd;
+      --accent: #c65a3a;
+      --link: #2569a8;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+    }
+
+    .wrap {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 22px 18px 10px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 36px;
+      line-height: 1.08;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      max-width: 980px;
+    }
+
+    .chart-subtitle,
+    .chart-note,
+    .source {
+      max-width: 980px;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 10px;
+      font-size: 17px;
+      line-height: 1.45;
+      color: #2f2f2f;
+    }
+
+    .chart-note {
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: var(--muted);
+    }
+
+    .legend-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      align-items: center;
+      margin-bottom: 8px;
+      font-size: 14px;
+      color: #4b4b4b;
+    }
+
+    .legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .legend-line {
+      width: 18px;
+      height: 0;
+      border-top: 4px solid var(--line);
+      display: inline-block;
+    }
+
+    #chart {
+      width: 100%;
+      height: 880px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 14px;
+      line-height: 1.4;
+      color: var(--muted);
+    }
+
+    .source a {
+      color: var(--link);
+    }
+
+    @media (max-width: 760px) {
+      .wrap {
+        padding: 16px 12px 8px;
+      }
+
+      .chart-title {
+        font-size: 29px;
+      }
+
+      .chart-subtitle {
+        font-size: 16px;
+      }
+
+      .chart-note,
+      .legend-row,
+      .source {
+        font-size: 14px;
+      }
+
+      #chart {
+        height: 980px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1 class="chart-title">
+      The Urban Order Is Tilting Toward <span style="color: var(--accent);">Asia and Africa</span>
+    </h1>
+    <p class="chart-subtitle">
+      Within the 20 cities projected to be largest in 2050, Dhaka and Jakarta rise to the top while older giants such as Tokyo, Mexico City, and São Paulo drift down the order. Several of the sharpest climbs come from South and Southeast Asia plus Africa.
+    </p>
+    <p class="chart-note">
+      The Voronoi table is keyed to 2050 population rank, so this chart takes the 20 cities projected to lead in 2050 and then re-ranks that same cohort at each year using the population values listed on the page. That keeps the bump chart readable while preserving the direction of change. On narrow screens, only the priority lines keep direct endpoint labels.
+    </p>
+    <div class="legend-row" aria-label="Bump chart legend">
+      <span class="legend-item"><span class="legend-line" style="border-top-color:#d1c8bd"></span>Top-20 context cities</span>
+      <span class="legend-item"><span class="legend-line" style="border-top-color:#c65a3a"></span>Dhaka, Jakarta, Tokyo, Guangzhou, Luanda, Mexico City, São Paulo</span>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Source:
+      <a href="https://www.voronoiapp.com/demographics/The-Worlds-Most-Populous-Cities-Over-Time-19752050-7639" target="_blank" rel="noreferrer">Voronoi / Visual Capitalist, "The World's Most Populous Cities Over Time (1975–2050)"</a>;
+      underlying source cited on the page:
+      <a href="https://population.un.org/wup/" target="_blank" rel="noreferrer">United Nations World Urbanization Prospects</a>.
+    </div>
+  </div>
+
+  <script>
+    const rows = [
+      { city: "Dhaka", country: "Bangladesh", highlight: true, color: "#c65a3a", populations: [5037174, 17434596, 36585479, 52123000] },
+      { city: "Jakarta", country: "Indonesia", highlight: true, color: "#d8863d", populations: [11696369, 25591966, 41913860, 51784000] },
+      { city: "Shanghai", country: "China", highlight: false, color: "#d1c8bd", populations: [4542787, 14034558, 29558908, 34912000] },
+      { city: "New Delhi", country: "India", highlight: false, color: "#d1c8bd", populations: [6091891, 17969092, 30222405, 33891000] },
+      { city: "Karachi", country: "Pakistan", highlight: false, color: "#d1c8bd", populations: [4626701, 10799503, 21422590, 32593000] },
+      { city: "Cairo", country: "Egypt", highlight: false, color: "#d1c8bd", populations: [7440914, 15676619, 25566102, 32366000] },
+      { city: "Tokyo", country: "Japan", highlight: true, color: "#5b7fa3", populations: [24281618, 30302560, 33412512, 30658000] },
+      { city: "Guangzhou", country: "China", highlight: true, color: "#3d9157", populations: [1644240, 18970258, 27563372, 29243000] },
+      { city: "Manila", country: "Philippines", highlight: false, color: "#d1c8bd", populations: [8329012, 17799064, 24735305, 27120000] },
+      { city: "Kolkata", country: "India", highlight: false, color: "#d1c8bd", populations: [10527605, 18355286, 22549738, 23768000] },
+      { city: "Mumbai", country: "India", highlight: false, color: "#d1c8bd", populations: [8338773, 15952862, 20203056, 23059000] },
+      { city: "Seoul", country: "Republic of Korea", highlight: false, color: "#d1c8bd", populations: [10079046, 18962544, 22490482, 21225000] },
+      { city: "Bangkok", country: "Thailand", highlight: false, color: "#d1c8bd", populations: [3650772, 8377066, 18180280, 20462000] },
+      { city: "Lahore", country: "Pakistan", highlight: false, color: "#d1c8bd", populations: [4402766, 7978805, 15156430, 20388000] },
+      { city: "Luanda", country: "Angola", highlight: true, color: "#8b61b4", populations: [306000, 714643, 11370127, 20286000] },
+      { city: "São Paulo", country: "Brazil", highlight: true, color: "#7d6a58", populations: [10536121, 16702008, 18949790, 18217000] },
+      { city: "Beijing", country: "China", highlight: false, color: "#d1c8bd", populations: [5154971, 9635380, 17013303, 18004000] },
+      { city: "Mexico City", country: "Mexico", highlight: true, color: "#9a6a3a", populations: [11119402, 17598162, 17734212, 17679000] },
+      { city: "Ho Chi Minh City", country: "Vietnam", highlight: false, color: "#d1c8bd", populations: [2384034, 6006090, 14052713, 17201000] },
+      { city: "Istanbul", country: "Türkiye", highlight: false, color: "#d1c8bd", populations: [5305193, 10633602, 15014763, 16303000] }
+    ];
+
+    const years = ["1975", "2000", "2025", "2050"];
+    const yearPositions = [0, 1, 2, 3];
+
+    rows.forEach((row) => {
+      row.ranks = years.map((_, yearIndex) => {
+        const ordered = rows
+          .slice()
+          .sort((a, b) => b.populations[yearIndex] - a.populations[yearIndex]);
+        return ordered.findIndex((d) => d.city === row.city) + 1;
+      });
+    });
+
+    function formatPopulation(value) {
+      return (value / 1000000).toFixed(1) + "M";
+    }
+
+    function reportHeight() {
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    function buildTraces(mobile) {
+      return rows.map((row) => {
+        const labelText = mobile
+          ? ["", "", "", row.highlight ? row.city : ""]
+          : ["", "", "", row.city];
+
+        return {
+          type: "scatter",
+          mode: "lines+markers+text",
+          x: yearPositions,
+          y: row.ranks,
+          name: row.city,
+          text: labelText,
+          textposition: "middle right",
+          textfont: {
+            size: mobile ? 12 : 12.5,
+            color: row.highlight ? row.color : "#666666"
+          },
+          cliponaxis: false,
+          line: {
+            color: row.highlight ? row.color : "rgba(190,180,170,0.78)",
+            width: row.highlight ? 3.8 : 1.8,
+            shape: "linear"
+          },
+          marker: {
+            size: row.highlight ? 7.5 : 5.5,
+            color: row.highlight ? row.color : "rgba(205,196,186,0.92)",
+            line: {
+              color: "#fcfbf7",
+              width: row.highlight ? 1.6 : 1.1
+            }
+          },
+          customdata: years.map((year, i) => [
+            row.city,
+            row.country,
+            year,
+            row.ranks[i],
+            row.populations[i]
+          ]),
+          hovertemplate:
+            "<b>%{customdata[0]}</b>, %{customdata[1]}<br>" +
+            "Year: %{customdata[2]}<br>" +
+            "Rank within selected 2050 top-20 cohort: %{customdata[3]}<br>" +
+            "Population: %{customdata[4]:,.0f}<extra></extra>",
+          showlegend: false
+        };
+      });
+    }
+
+    function buildLayout() {
+      const mobile = window.innerWidth <= 760;
+
+      return {
+        paper_bgcolor: "#fcfbf7",
+        plot_bgcolor: "#fcfbf7",
+        font: {
+          family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+          color: "#222222",
+          size: mobile ? 13 : 14
+        },
+        margin: {
+          l: mobile ? 56 : 70,
+          r: mobile ? 116 : 170,
+          t: 8,
+          b: 48
+        },
+        hovermode: "closest",
+        showlegend: false,
+        xaxis: {
+          type: "linear",
+          range: [-0.18, 3.18],
+          tickmode: "array",
+          tickvals: yearPositions,
+          ticktext: years,
+          tickfont: {
+            size: mobile ? 12 : 13,
+            color: "#4d4d4d"
+          },
+          showgrid: true,
+          gridcolor: "#e6e0d8",
+          gridwidth: 1,
+          zeroline: false,
+          fixedrange: true
+        },
+        yaxis: {
+          autorange: "reversed",
+          range: [20.5, 0.5],
+          tickmode: "array",
+          tickvals: Array.from({ length: 20 }, (_, i) => i + 1),
+          ticktext: Array.from({ length: 20 }, (_, i) => String(i + 1)),
+          title: {
+            text: "Rank",
+            standoff: 8
+          },
+          titlefont: {
+            size: mobile ? 12 : 13,
+            color: "#5a5a5a"
+          },
+          tickfont: {
+            size: mobile ? 11 : 12,
+            color: "#5a5a5a"
+          },
+          showgrid: true,
+          gridcolor: "rgba(230,224,216,0.48)",
+          zeroline: false,
+          fixedrange: true
+        },
+        annotations: mobile ? [] : [
+          {
+            x: 0,
+            y: 1,
+            xref: "x",
+            yref: "y",
+            text: "Tokyo starts as<br>No. 1 in this cohort",
+            showarrow: false,
+            xanchor: "right",
+            align: "right",
+            xshift: -12,
+            font: {
+              size: 12,
+              color: "#5b7fa3"
+            }
+          }
+        ]
+      };
+    }
+
+    const config = {
+      responsive: true,
+      displayModeBar: false
+    };
+
+    function renderChart() {
+      const mobile = window.innerWidth <= 760;
+      Plotly.newPlot("chart", buildTraces(mobile), buildLayout(), config).then(reportHeight);
+    }
+
+    let resizeTimer;
+    window.addEventListener("resize", () => {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(renderChart, 120);
+    });
+
+    renderChart();
+    window.addEventListener("load", reportHeight);
+  </script>
+</body>
+</html>

--- a/assets/viz/weekly-zori-quadrant/index.html
+++ b/assets/viz/weekly-zori-quadrant/index.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Which Rental Markets Cooled After the Pandemic Boom?</title>
+  <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+  <style>
+    body {
+      margin: 0;
+      font-family: "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif;
+      background: #ffffff;
+      color: #111111;
+    }
+
+    .wrap {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 20px 18px 8px;
+    }
+
+    .chart-header {
+      margin-bottom: 8px;
+    }
+
+    .chart-title {
+      margin: 0 0 8px;
+      font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+      font-size: 32px;
+      line-height: 1.12;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: #111111;
+    }
+
+    .chart-subtitle {
+      margin: 0 0 14px;
+      font-size: 17px;
+      line-height: 1.4;
+      color: #333333;
+      max-width: 980px;
+    }
+
+    .legend-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      align-items: center;
+      margin-bottom: 6px;
+      font-size: 16px;
+      color: #333333;
+    }
+
+    .legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .legend-dot {
+      width: 14px;
+      height: 14px;
+      border-radius: 999px;
+      display: inline-block;
+    }
+
+    #chart {
+      width: 100%;
+      height: 700px;
+    }
+
+    .source {
+      margin-top: 10px;
+      font-size: 15px;
+      color: #6d6d6d;
+    }
+
+    .source a {
+      color: #2c8fce;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="chart-header">
+      <h1 class="chart-title">
+        Which US Rental Markets <span style="color:#BE123C">Cooled</span> After the Pandemic <span style="color:#F28E2B">Boom</span>?
+      </h1>
+      <p class="chart-subtitle">
+        Top 25 metro areas by size rank, plus Austin. Sun Belt metros surged faster by August 2022, while several large coastal and Midwest metros kept climbing through February 2026.
+      </p>
+      <div class="legend-row" aria-label="Regions">
+        <span class="legend-item"><span class="legend-dot" style="background:#4E79A7"></span>Northeast</span>
+        <span class="legend-item"><span class="legend-dot" style="background:#9C6ADE"></span>Midwest</span>
+        <span class="legend-item"><span class="legend-dot" style="background:#F28E2B"></span>South</span>
+        <span class="legend-item"><span class="legend-dot" style="background:#59A14F"></span>West</span>
+      </div>
+    </div>
+    <div id="chart"></div>
+    <div class="source">
+      Data Source:
+      <a href="https://www.zillow.com/research/data/" target="_blank" rel="noreferrer">Zillow Observed Rent Index (ZORI)</a>
+      | Selected metros are the top 25 by size rank plus Austin, TX
+    </div>
+  </div>
+
+  <script>
+    function reportHeight() {
+      const height = Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight
+      );
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: "weekly-viz-height", height }, "*");
+      }
+    }
+
+    const metros = [
+      {"rank":1,"name":"New York, NY","state":"NY","region":"Northeast","zori_2019":2448.2,"zori_2022":2918.1,"zori_2026":3258.4,"surge_pct":19.2,"since_peak_pct":11.7,"total_pct":33.1},
+      {"rank":2,"name":"Los Angeles, CA","state":"CA","region":"West","zori_2019":2246.3,"zori_2022":2702.5,"zori_2026":2884.1,"surge_pct":20.3,"since_peak_pct":6.7,"total_pct":28.4},
+      {"rank":3,"name":"Chicago, IL","state":"IL","region":"Midwest","zori_2019":1542.8,"zori_2022":1802.1,"zori_2026":2132.3,"surge_pct":16.8,"since_peak_pct":18.3,"total_pct":38.2},
+      {"rank":4,"name":"Dallas, TX","state":"TX","region":"South","zori_2019":1283.3,"zori_2022":1661.7,"zori_2026":1630.4,"surge_pct":29.5,"since_peak_pct":-1.9,"total_pct":27.0},
+      {"rank":5,"name":"Houston, TX","state":"TX","region":"South","zori_2019":1327.0,"zori_2022":1575.5,"zori_2026":1619.5,"surge_pct":18.7,"since_peak_pct":2.8,"total_pct":22.0},
+      {"rank":6,"name":"Washington, DC","state":"VA","region":"South","zori_2019":1875.7,"zori_2022":2165.5,"zori_2026":2331.4,"surge_pct":15.5,"since_peak_pct":7.7,"total_pct":24.3},
+      {"rank":7,"name":"Philadelphia, PA","state":"PA","region":"Northeast","zori_2019":1382.7,"zori_2022":1670.1,"zori_2026":1858.8,"surge_pct":20.8,"since_peak_pct":11.3,"total_pct":34.4},
+      {"rank":8,"name":"Miami, FL","state":"FL","region":"South","zori_2019":1729.3,"zori_2022":2529.3,"zori_2026":2654.1,"surge_pct":46.3,"since_peak_pct":4.9,"total_pct":53.5},
+      {"rank":9,"name":"Atlanta, GA","state":"GA","region":"South","zori_2019":1305.8,"zori_2022":1771.2,"zori_2026":1808.0,"surge_pct":35.6,"since_peak_pct":2.1,"total_pct":38.5},
+      {"rank":10,"name":"Boston, MA","state":"MA","region":"Northeast","zori_2019":2381.4,"zori_2022":2758.4,"zori_2026":3097.7,"surge_pct":15.8,"since_peak_pct":12.3,"total_pct":30.1},
+      {"rank":11,"name":"Phoenix, AZ","state":"AZ","region":"West","zori_2019":1261.0,"zori_2022":1754.7,"zori_2026":1723.9,"surge_pct":39.1,"since_peak_pct":-1.8,"total_pct":36.7},
+      {"rank":12,"name":"San Francisco, CA","state":"CA","region":"West","zori_2019":2711.4,"zori_2022":2859.6,"zori_2026":3103.0,"surge_pct":5.5,"since_peak_pct":8.5,"total_pct":14.4},
+      {"rank":13,"name":"Riverside, CA","state":"CA","region":"West","zori_2019":1671.9,"zori_2022":2300.2,"zori_2026":2478.0,"surge_pct":37.6,"since_peak_pct":7.7,"total_pct":48.2},
+      {"rank":14,"name":"Detroit, MI","state":"MI","region":"Midwest","zori_2019":1028.5,"zori_2022":1318.7,"zori_2026":1461.4,"surge_pct":28.2,"since_peak_pct":10.8,"total_pct":42.1},
+      {"rank":15,"name":"Seattle, WA","state":"WA","region":"West","zori_2019":1735.0,"zori_2022":2089.9,"zori_2026":2181.3,"surge_pct":20.5,"since_peak_pct":4.4,"total_pct":25.7},
+      {"rank":16,"name":"Minneapolis, MN","state":"MN","region":"Midwest","zori_2019":1358.5,"zori_2022":1515.2,"zori_2026":1664.4,"surge_pct":11.5,"since_peak_pct":9.8,"total_pct":22.5},
+      {"rank":17,"name":"San Diego, CA","state":"CA","region":"West","zori_2019":2030.1,"zori_2022":2703.5,"zori_2026":2871.4,"surge_pct":33.2,"since_peak_pct":6.2,"total_pct":41.4},
+      {"rank":18,"name":"Tampa, FL","state":"FL","region":"South","zori_2019":1313.4,"zori_2022":1909.0,"zori_2026":1975.9,"surge_pct":45.3,"since_peak_pct":3.5,"total_pct":50.4},
+      {"rank":19,"name":"Denver, CO","state":"CO","region":"West","zori_2019":1541.6,"zori_2022":1868.6,"zori_2026":1843.7,"surge_pct":21.2,"since_peak_pct":-1.3,"total_pct":19.6},
+      {"rank":20,"name":"Baltimore, MD","state":"MD","region":"South","zori_2019":1400.5,"zori_2022":1697.4,"zori_2026":1857.1,"surge_pct":21.2,"since_peak_pct":9.4,"total_pct":32.6},
+      {"rank":21,"name":"St. Louis, MO","state":"MO","region":"Midwest","zori_2019":971.2,"zori_2022":1211.8,"zori_2026":1395.2,"surge_pct":24.8,"since_peak_pct":15.1,"total_pct":43.7},
+      {"rank":22,"name":"Orlando, FL","state":"FL","region":"South","zori_2019":1401.5,"zori_2022":1910.9,"zori_2026":1922.4,"surge_pct":36.3,"since_peak_pct":0.6,"total_pct":37.2},
+      {"rank":23,"name":"Charlotte, NC","state":"NC","region":"South","zori_2019":1258.3,"zori_2022":1666.0,"zori_2026":1715.8,"surge_pct":32.4,"since_peak_pct":3.0,"total_pct":36.4},
+      {"rank":24,"name":"San Antonio, TX","state":"TX","region":"South","zori_2019":1183.9,"zori_2022":1457.2,"zori_2026":1391.8,"surge_pct":23.1,"since_peak_pct":-4.5,"total_pct":17.6},
+      {"rank":25,"name":"Portland, OR","state":"OR","region":"West","zori_2019":1420.8,"zori_2022":1742.8,"zori_2026":1778.7,"surge_pct":22.7,"since_peak_pct":2.1,"total_pct":25.2},
+      {"rank":29,"name":"Austin, TX","state":"TX","region":"South","zori_2019":1366.0,"zori_2022":1781.7,"zori_2026":1563.2,"surge_pct":30.4,"since_peak_pct":-12.3,"total_pct":14.4}
+    ];
+
+    const medianSurge = 22.9;
+    const regionColors = {
+      Northeast: "#4E79A7",
+      Midwest: "#9C6ADE",
+      South: "#F28E2B",
+      West: "#59A14F"
+    };
+    const highlightLabels = new Set([
+      "Austin, TX",
+      "San Antonio, TX",
+      "Phoenix, AZ",
+      "Dallas, TX",
+      "Boston, MA",
+      "New York, NY",
+      "San Francisco, CA",
+      "Miami, FL",
+      "St. Louis, MO"
+    ]);
+    const labelPositions = {
+      "Austin, TX": { ax: 84, ay: 16, bgcolor: "rgba(255,255,255,0.94)" },
+      "San Antonio, TX": { ax: 72, ay: 28, bgcolor: "rgba(255,255,255,0.94)" },
+      "Phoenix, AZ": { ax: 78, ay: -18, bgcolor: "rgba(255,255,255,0.94)" },
+      "Dallas, TX": { ax: 70, ay: -18, bgcolor: "rgba(255,255,255,0.94)" },
+      "Chicago, IL": { ax: 24, ay: -42, bgcolor: "rgba(255,255,255,0.94)" },
+      "Boston, MA": { ax: 60, ay: -36, bgcolor: "rgba(255,255,255,0.94)" },
+      "New York, NY": { ax: 64, ay: 22, bgcolor: "rgba(255,255,255,0.94)" },
+      "San Francisco, CA": { ax: 28, ay: -46, bgcolor: "rgba(255,255,255,0.94)" },
+      "Miami, FL": { ax: -58, ay: -34, bgcolor: "rgba(255,255,255,0.94)" },
+      "St. Louis, MO": { ax: 70, ay: -18, bgcolor: "rgba(255,255,255,0.94)" }
+    };
+
+    const traces = Object.keys(regionColors).map((region) => {
+      const rows = metros.filter((d) => d.region === region);
+      return {
+        type: "scatter",
+        mode: "markers",
+        name: region,
+        x: rows.map((d) => d.surge_pct),
+        y: rows.map((d) => d.since_peak_pct),
+        hovertext: rows.map((d) => d.name),
+        marker: {
+          size: rows.map((d) => 12 + (d.zori_2026 - 1300) / 120),
+          color: regionColors[region],
+          line: { color: "#ffffff", width: 1.5 },
+          opacity: 0.92
+        },
+        customdata: rows.map((d) => [
+          d.rank,
+          d.zori_2019,
+          d.zori_2022,
+          d.zori_2026,
+          d.total_pct
+        ]),
+        hovertemplate:
+          "<b>%{hovertext}</b><br>" +
+          "Size rank: %{customdata[0]}<br>" +
+          "2019 ZORI: $%{customdata[1]:,.0f}<br>" +
+          "Aug 2022 ZORI: $%{customdata[2]:,.0f}<br>" +
+          "Feb 2026 ZORI: $%{customdata[3]:,.0f}<br>" +
+          "2019 to 2022: %{x:.1f}%<br>" +
+          "2022 to 2026: %{y:.1f}%<br>" +
+          "Total change: %{customdata[4]:.1f}%<extra></extra>"
+      };
+    });
+
+    const layout = {
+      paper_bgcolor: "#ffffff",
+      plot_bgcolor: "#ffffff",
+      font: {
+        family: "\"IBM Plex Sans\", \"Avenir Next\", \"Segoe UI\", sans-serif",
+        color: "#222222",
+        size: 16
+      },
+      margin: { l: 80, r: 40, t: 24, b: 95 },
+      xaxis: {
+        title: {
+          text: "ZORI change from Dec 2019 to Aug 2022",
+          standoff: 18
+        },
+        range: [0, 52],
+        ticksuffix: "%",
+        showgrid: true,
+        gridcolor: "#E4E8EE",
+        zeroline: false,
+        automargin: true
+      },
+      yaxis: {
+        title: {
+          text: "ZORI change from Aug 2022 to Feb 2026",
+          standoff: 16
+        },
+        range: [-16, 21],
+        ticksuffix: "%",
+        showgrid: true,
+        gridcolor: "#E4E8EE",
+        zeroline: false,
+        automargin: true
+      },
+      showlegend: false,
+      shapes: [
+        { type: "rect", x0: 0, x1: medianSurge, y0: 0, y1: 21, fillcolor: "rgba(78,121,167,0.08)", line: { width: 0 } },
+        { type: "rect", x0: medianSurge, x1: 52, y0: 0, y1: 21, fillcolor: "rgba(89,161,79,0.08)", line: { width: 0 } },
+        { type: "rect", x0: 0, x1: medianSurge, y0: -16, y1: 0, fillcolor: "rgba(205,215,228,0.18)", line: { width: 0 } },
+        { type: "rect", x0: medianSurge, x1: 52, y0: -16, y1: 0, fillcolor: "rgba(190,18,60,0.08)", line: { width: 0 } },
+        { type: "line", x0: medianSurge, x1: medianSurge, y0: -16, y1: 21, line: { color: "#98A2B3", width: 1.5, dash: "dot" } },
+        { type: "line", x0: 0, x1: 52, y0: 0, y1: 0, line: { color: "#98A2B3", width: 1.5, dash: "dot" } }
+      ],
+      annotations: [
+        {
+          x: 5.5,
+          y: 19.2,
+          xref: "x",
+          yref: "y",
+          text: "Lower early surge,<br>still rising",
+          showarrow: false,
+          align: "left",
+          font: { size: 13, color: "#4E79A7" }
+        },
+        {
+          x: 28,
+          y: 19.2,
+          xref: "x",
+          yref: "y",
+          text: "Big boom,<br>still climbing",
+          showarrow: false,
+          align: "left",
+          font: { size: 13, color: "#3B7A3E" }
+        },
+        {
+          x: 46.5,
+          y: -13.2,
+          xref: "x",
+          yref: "y",
+          text: "Big boom,<br>then cooled",
+          showarrow: false,
+          align: "left",
+          font: { size: 13, color: "#BE123C" }
+        },
+        {
+          x: 17,
+          y: 18.3,
+          xref: "x",
+          yref: "y",
+          text: "Chicago kept rising well after 2022",
+          showarrow: true,
+          arrowcolor: "#4E79A7",
+          ax: 76,
+          ay: 20,
+          bgcolor: "rgba(255,255,255,0.92)",
+          bordercolor: "rgba(78,121,167,0.22)",
+          borderwidth: 1,
+          font: { size: 13, color: "#244B6D" }
+        },
+        ...metros
+          .filter((d) => highlightLabels.has(d.name))
+          .map((d) => ({
+            x: d.surge_pct,
+            y: d.since_peak_pct,
+            xref: "x",
+            yref: "y",
+            text: d.name,
+            showarrow: true,
+            arrowhead: 0,
+            arrowsize: 1,
+            arrowwidth: 1,
+            arrowcolor: "#98A2B3",
+            ax: labelPositions[d.name].ax,
+            ay: labelPositions[d.name].ay,
+            bgcolor: labelPositions[d.name].bgcolor,
+            bordercolor: "rgba(152,162,179,0.28)",
+            borderwidth: 1,
+            borderpad: 3,
+            font: { size: 12, color: "#111111" },
+            align: "left"
+          })),
+        {
+          x: 30.4,
+          y: -13.2,
+          xref: "x",
+          yref: "y",
+          text: "Austin had the sharpest pullback<br>among these major metros",
+          showarrow: true,
+          arrowcolor: "#BE123C",
+          ax: 102,
+          ay: 42,
+          bgcolor: "rgba(255,255,255,0.94)",
+          bordercolor: "rgba(190,18,60,0.22)",
+          borderwidth: 1,
+          font: { size: 13, color: "#6B102B" }
+        }
+      ]
+    };
+
+    Plotly.newPlot("chart", traces, layout, {
+      responsive: true,
+      displayModeBar: false
+    });
+
+    window.addEventListener("load", reportHeight);
+    window.addEventListener("resize", reportHeight);
+    setTimeout(reportHeight, 300);
+    setTimeout(reportHeight, 1000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Plotly comparison sections below the existing Tableau embeds in the weekly data viz posts from 2026-02-02 through 2026-03-30
- add the generated Plotly HTML assets under `assets/viz/...` so the comparison iframes resolve inside the site
- include both generated air-routes variants in the 2026-03-02 post for side-by-side comparison of alternative chart forms

## Scope note
- this PR updates the existing matching posts currently in the repo
- it does not add April 2026 posts, since those corresponding post files are not present on `master` yet